### PR TITLE
feat(properties): Add two-way Tailwind CSS editor panel

### DIFF
--- a/apps/boxout/src/app/app.component.ts
+++ b/apps/boxout/src/app/app.component.ts
@@ -38,7 +38,7 @@ export class AppComponent {
   protected canvasService = inject(CanvasService);
   protected guideService = inject(GuideService);
   protected layoutStateService = inject(LayoutStateService);
-  private canvasSelectionService = inject(SelectionService);
+  private selectionService = inject(SelectionService);
   private documentService = inject(DocumentService);
 
   constructor() {
@@ -47,7 +47,7 @@ export class AppComponent {
 
   private async initializeApp(): Promise<void> {
     await this.documentService.initialize();
-    this.canvasSelectionService.setSelectedItemKey(
+    this.selectionService.setSelectedItemKey(
       this.canvasService.items[0]?.key
     );
   }

--- a/apps/boxout/src/app/properties-panel/properties-panel.component.html
+++ b/apps/boxout/src/app/properties-panel/properties-panel.component.html
@@ -1,11 +1,11 @@
-<div class="flex flex-col w-full">
+<div class="flex flex-col w-full min-w-0">
   @if (frame(); as selectedFrame) {
     <div
-      class="flex grow flex-col self-stretch rounded-3xl bg-[var(--bg-primary)] overflow-auto relative"
+      class="flex grow flex-col self-stretch rounded-3xl bg-[var(--bg-primary)] overflow-hidden relative min-w-0"
     >
       <!-- Scrollable content area -->
-      <div class="flex-1 overflow-y-auto pb-50">
-        <div class="sticky top-0 bg-[var(--bg-primary)] px-4 pt-4 pb-2 z-10">
+      <div class="flex-1 overflow-y-auto overflow-x-hidden pb-50 min-w-0">
+        <div class="sticky top-0 bg-[var(--bg-primary)] px-4 pt-4 pb-2 z-10 min-w-0 overflow-hidden">
           <p-inputgroup>
             <input
               #searchInput
@@ -25,6 +25,15 @@
               (click)="searchText.set('')"
             >.</button>
           </p-inputgroup>
+
+          <!-- Tailwind Classes Editor -->
+          <app-tailwind-panel
+            class="mt-3 block"
+            [css]="selectedFrame.css"
+            [tailwindClasses]="selectedFrame.tailwindClasses"
+            [hasSelection]="true"
+            [compact]="true"
+          ></app-tailwind-panel>
         </div>
 
         <div class="flex flex-col">

--- a/apps/boxout/src/app/properties-panel/properties-panel.component.ts
+++ b/apps/boxout/src/app/properties-panel/properties-panel.component.ts
@@ -29,6 +29,7 @@ import {
   PropertiesConfig,
   PropertiesService,
   PropertiesKeyboardNavigationService,
+  TailwindPanelComponent,
 } from '@layout/properties';
 import { THEME_CONFIG } from '@layout/shared';
 import { ThemeService } from '../core/theme/theme.service';
@@ -43,7 +44,8 @@ import { ThemeService } from '../core/theme/theme.service';
     SizingSpacingComponent,
     LayoutComponent,
     MetaDataComponent,
-    PropertiesFlexboxGridComponent
+    PropertiesFlexboxGridComponent,
+    TailwindPanelComponent,
   ],
   providers: [
     PropertiesService,

--- a/libs/properties/src/index.ts
+++ b/libs/properties/src/index.ts
@@ -14,6 +14,9 @@ export * from './lib/groups/layout.component';
 export * from './lib/groups/meta-data.component';
 export * from './lib/groups/sizing-spacing.component';
 
+// Panels
+export * from './lib/tailwind-panel/tailwind-panel.component';
+
 // Services, Config, Directives
 export * from './lib/properties.service';
 export * from './lib/properties.config';

--- a/libs/properties/src/lib/tailwind-panel/tailwind-panel.component.html
+++ b/libs/properties/src/lib/tailwind-panel/tailwind-panel.component.html
@@ -1,0 +1,106 @@
+@if (hasSelection()) {
+  @if (compact()) {
+    <!-- Compact mode: just the editor with minimal chrome -->
+    <div class="flex flex-col gap-1">
+      <div class="flex items-center justify-between">
+        <span
+          class="text-xs font-medium text-surface-600 dark:text-surface-400"
+        >
+          Tailwind Classes
+        </span>
+        @if (unsupportedClassCount() > 0) {
+          <span
+            class="text-[10px] text-surface-400 dark:text-surface-500"
+            title="Classes not synced to properties (colors, variants, etc.)"
+          >
+            {{ syncedClassCount() }} synced, {{ unsupportedClassCount() }} extra
+          </span>
+        }
+      </div>
+      <shared-code-editor
+        [ngModel]="editorValue()"
+        (ngModelChange)="onEditorChange($event)"
+        [placeholder]="'flex gap-4 justify-center...'"
+        [multiline]="false"
+        [extensions]="editorExtensions()"
+        [darkMode]="isDarkMode()"
+      />
+    </div>
+  } @else {
+    <!-- Full mode: header, editor, and info panel -->
+    <div class="flex flex-col h-full">
+      <!-- Header -->
+      <div class="px-4 py-3 border-b border-surface-200 dark:border-surface-700">
+        <h2 class="text-base font-semibold text-surface-900 dark:text-surface-50 m-0">
+          Tailwind CSS
+        </h2>
+        <p class="text-xs text-surface-500 dark:text-surface-400 mt-1 mb-0">
+          Edit classes to update properties, or change properties to see generated classes
+        </p>
+      </div>
+
+      <!-- Editor -->
+      <div class="flex-1 overflow-auto p-4">
+        <div class="mb-2">
+          <span
+            class="text-xs font-medium text-surface-600 dark:text-surface-400 uppercase tracking-wide"
+          >
+            Classes
+          </span>
+        </div>
+        <shared-code-editor
+          [ngModel]="editorValue()"
+          (ngModelChange)="onEditorChange($event)"
+          [placeholder]="'flex gap-4 justify-center items-center...'"
+          [multiline]="true"
+          [extensions]="editorExtensions()"
+          [darkMode]="isDarkMode()"
+        />
+
+        <!-- Info panel -->
+        <div class="mt-4 p-3 bg-surface-50 dark:bg-surface-800 rounded-lg">
+          <div class="flex items-start gap-2">
+            <i class="pi pi-info-circle text-primary-500 mt-0.5"></i>
+            <div class="text-xs text-surface-600 dark:text-surface-400">
+              <p class="m-0 mb-2">
+                <strong>Synced classes</strong> ({{ syncedClassCount() }}):
+                Layout, spacing, sizing, flexbox, and grid properties
+              </p>
+              <p class="m-0">
+                <strong>Preserved classes</strong> ({{ unsupportedClassCount() }}):
+                Colors, typography, responsive variants, and other utilities
+              </p>
+            </div>
+          </div>
+        </div>
+
+        @if (unsupportedClasses().length > 0) {
+          <div class="mt-4">
+            <span
+              class="text-xs font-medium text-surface-600 dark:text-surface-400 uppercase tracking-wide"
+            >
+              Preserved Classes (not synced)
+            </span>
+            <div
+              class="mt-2 p-2 bg-surface-100 dark:bg-surface-800 rounded text-xs font-mono text-surface-600 dark:text-surface-400 break-all"
+            >
+              {{ unsupportedClasses().join(' ') }}
+            </div>
+          </div>
+        }
+      </div>
+    </div>
+  }
+} @else {
+  <!-- No selection state (only shown in non-compact mode) -->
+  @if (!compact()) {
+    <div class="flex flex-col items-center justify-center h-full px-6 text-center">
+      <div class="text-muted-color text-sm">
+        <p class="mb-2">No element selected</p>
+        <p class="text-xs opacity-70">
+          Select an element to edit its Tailwind classes
+        </p>
+      </div>
+    </div>
+  }
+}

--- a/libs/properties/src/lib/tailwind-panel/tailwind-panel.component.scss
+++ b/libs/properties/src/lib/tailwind-panel/tailwind-panel.component.scss
@@ -1,0 +1,49 @@
+:host {
+  display: block;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+:host:not(.compact) {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+// Ensure all flex children can shrink
+:host ::ng-deep {
+  .flex {
+    min-width: 0;
+  }
+
+  shared-code-editor {
+    display: block;
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+    overflow: hidden;
+  }
+
+  // Force CodeMirror to respect container width
+  .cm-editor {
+    max-width: 100%;
+  }
+
+  .cm-scroller {
+    overflow-x: hidden !important;
+  }
+
+  .cm-content {
+    max-width: 100%;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+  }
+
+  .cm-line {
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    white-space: pre-wrap !important;
+  }
+}

--- a/libs/properties/src/lib/tailwind-panel/tailwind-panel.component.spec.ts
+++ b/libs/properties/src/lib/tailwind-panel/tailwind-panel.component.spec.ts
@@ -1,0 +1,372 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TailwindPanelComponent } from './tailwind-panel.component';
+import { TailwindCssConverter } from '@layout/serialization';
+import { CanvasService } from '@layout/canvas';
+import { THEME_CONFIG } from '@layout/shared';
+import { Css } from '@layout/models';
+import { Component, signal } from '@angular/core';
+
+// Test host component to test input bindings
+@Component({
+  template: `
+    <app-tailwind-panel
+      [css]="css()"
+      [tailwindClasses]="tailwindClasses()"
+      [hasSelection]="hasSelection()"
+      [compact]="compact()"
+    />
+  `,
+  imports: [TailwindPanelComponent],
+})
+class TestHostComponent {
+  css = signal<Css | undefined>(undefined);
+  tailwindClasses = signal<string | undefined>(undefined);
+  hasSelection = signal(false);
+  compact = signal(false);
+}
+
+describe('TailwindPanelComponent', () => {
+  let component: TailwindPanelComponent;
+  let fixture: ComponentFixture<TailwindPanelComponent>;
+  let mockConverter: {
+    cssToTailwind: ReturnType<typeof vi.fn>;
+    tailwindToCss: ReturnType<typeof vi.fn>;
+  };
+  let mockCanvasService: {
+    updateCss: ReturnType<typeof vi.fn>;
+    updateTailwindClasses: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(async () => {
+    mockConverter = {
+      cssToTailwind: vi.fn().mockReturnValue([]),
+      tailwindToCss: vi.fn().mockReturnValue({ css: {}, unsupportedClasses: [] }),
+    };
+
+    mockCanvasService = {
+      updateCss: vi.fn(),
+      updateTailwindClasses: vi.fn(),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [TailwindPanelComponent],
+      providers: [
+        { provide: TailwindCssConverter, useValue: mockConverter },
+        { provide: CanvasService, useValue: mockCanvasService },
+        { provide: THEME_CONFIG, useValue: { darkMode: false } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TailwindPanelComponent);
+    component = fixture.componentInstance;
+  });
+
+  describe('WHEN component is created', () => {
+    it('SHOULD create the component', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('SHOULD have default input values', () => {
+      expect(component.css()).toBeUndefined();
+      expect(component.tailwindClasses()).toBeUndefined();
+      expect(component.hasSelection()).toBe(false);
+      expect(component.compact()).toBe(false);
+    });
+  });
+
+  describe('WHEN hasSelection is false', () => {
+    it('SHOULD not render content in compact mode', () => {
+      fixture.componentRef.setInput('hasSelection', false);
+      fixture.componentRef.setInput('compact', true);
+      fixture.detectChanges();
+
+      const content = fixture.nativeElement.querySelector('.flex');
+      expect(content).toBeNull();
+    });
+
+    it('SHOULD render no selection message in non-compact mode', () => {
+      fixture.componentRef.setInput('hasSelection', false);
+      fixture.componentRef.setInput('compact', false);
+      fixture.detectChanges();
+
+      const message = fixture.nativeElement.textContent;
+      expect(message).toContain('No element selected');
+    });
+  });
+
+  describe('WHEN hasSelection is true', () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput('hasSelection', true);
+    });
+
+    it('SHOULD render editor in compact mode', () => {
+      fixture.componentRef.setInput('compact', true);
+      fixture.detectChanges();
+
+      const label = fixture.nativeElement.textContent;
+      expect(label).toContain('Tailwind Classes');
+    });
+
+    it('SHOULD render full panel in non-compact mode', () => {
+      fixture.componentRef.setInput('compact', false);
+      fixture.detectChanges();
+
+      const header = fixture.nativeElement.textContent;
+      expect(header).toContain('Tailwind CSS');
+    });
+  });
+
+  describe('WHEN CSS input changes', () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput('hasSelection', true);
+      fixture.componentRef.setInput('compact', true);
+    });
+
+    it('SHOULD convert CSS to Tailwind classes', async () => {
+      const css: Css = { layout: { display: 'flex' } };
+      mockConverter.cssToTailwind.mockReturnValue(['flex']);
+      mockConverter.tailwindToCss.mockReturnValue({ css: {}, unsupportedClasses: [] });
+
+      fixture.componentRef.setInput('css', css);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(mockConverter.cssToTailwind).toHaveBeenCalledWith(css);
+    });
+
+    it('SHOULD combine CSS-derived classes with extra unsupported classes', async () => {
+      const css: Css = { layout: { display: 'flex' } };
+      mockConverter.cssToTailwind.mockReturnValue(['flex']);
+      mockConverter.tailwindToCss.mockReturnValue({ css: {}, unsupportedClasses: ['bg-blue-500'] });
+
+      fixture.componentRef.setInput('css', css);
+      fixture.componentRef.setInput('tailwindClasses', 'bg-blue-500');
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(mockConverter.cssToTailwind).toHaveBeenCalled();
+      expect(mockConverter.tailwindToCss).toHaveBeenCalledWith('bg-blue-500');
+    });
+  });
+
+  describe('WHEN user edits Tailwind classes', () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput('hasSelection', true);
+      fixture.componentRef.setInput('compact', true);
+      fixture.detectChanges();
+    });
+
+    it('SHOULD parse classes and update CSS', async () => {
+      const parsedResult = {
+        css: { layout: { display: 'flex' } },
+        unsupportedClasses: [],
+      };
+      mockConverter.tailwindToCss.mockReturnValue(parsedResult);
+
+      component['onEditorChange']('flex');
+
+      expect(mockConverter.tailwindToCss).toHaveBeenCalledWith('flex');
+      expect(mockCanvasService.updateCss).toHaveBeenCalled();
+    });
+
+    it('SHOULD update tailwindClasses with unsupported classes', () => {
+      const parsedResult = {
+        css: { layout: { display: 'flex' } },
+        unsupportedClasses: ['bg-blue-500', 'text-white'],
+      };
+      mockConverter.tailwindToCss.mockReturnValue(parsedResult);
+
+      component['onEditorChange']('flex bg-blue-500 text-white');
+
+      expect(mockCanvasService.updateTailwindClasses).toHaveBeenCalledWith('bg-blue-500 text-white');
+    });
+
+    it('SHOULD handle empty input', () => {
+      mockConverter.tailwindToCss.mockReturnValue({ css: {}, unsupportedClasses: [] });
+
+      component['onEditorChange']('');
+
+      expect(mockCanvasService.updateCss).toHaveBeenCalled();
+      expect(mockCanvasService.updateTailwindClasses).toHaveBeenCalledWith('');
+    });
+  });
+
+  describe('computed signals', () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput('hasSelection', true);
+    });
+
+    it('SHOULD compute syncedClassCount from CSS', async () => {
+      mockConverter.cssToTailwind.mockReturnValue(['flex', 'gap-4', 'items-center']);
+      mockConverter.tailwindToCss.mockReturnValue({ css: {}, unsupportedClasses: [] });
+
+      const css: Css = {
+        layout: { display: 'flex' },
+        flexboxGrid: { gap: '1rem', alignItems: 'center' },
+      };
+      fixture.componentRef.setInput('css', css);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      // syncedClassCount is computed from cssToTailwind result length
+      expect(mockConverter.cssToTailwind).toHaveBeenCalled();
+    });
+
+    it('SHOULD track unsupportedClasses from tailwindClasses input', async () => {
+      mockConverter.cssToTailwind.mockReturnValue([]);
+      mockConverter.tailwindToCss.mockReturnValue({
+        css: {},
+        unsupportedClasses: ['bg-blue-500', 'text-white'],
+      });
+
+      fixture.componentRef.setInput('tailwindClasses', 'bg-blue-500 text-white');
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(mockConverter.tailwindToCss).toHaveBeenCalledWith('bg-blue-500 text-white');
+    });
+  });
+
+  describe('WHEN compact mode shows class counts', () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput('hasSelection', true);
+      fixture.componentRef.setInput('compact', true);
+    });
+
+    it('SHOULD show synced and extra counts when there are unsupported classes', async () => {
+      mockConverter.cssToTailwind.mockReturnValue(['flex']);
+      mockConverter.tailwindToCss.mockReturnValue({
+        css: {},
+        unsupportedClasses: ['bg-blue-500'],
+      });
+
+      fixture.componentRef.setInput('css', { layout: { display: 'flex' } });
+      fixture.componentRef.setInput('tailwindClasses', 'bg-blue-500');
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const text = fixture.nativeElement.textContent;
+      // The template shows "X synced, Y extra" when unsupportedClassCount > 0
+      expect(text).toContain('synced');
+    });
+  });
+
+  describe('dark mode', () => {
+    it('SHOULD use dark mode from theme config', async () => {
+      await TestBed.resetTestingModule();
+      await TestBed.configureTestingModule({
+        imports: [TailwindPanelComponent],
+        providers: [
+          { provide: TailwindCssConverter, useValue: mockConverter },
+          { provide: CanvasService, useValue: mockCanvasService },
+          { provide: THEME_CONFIG, useValue: { darkMode: true } },
+        ],
+      }).compileComponents();
+
+      const darkFixture = TestBed.createComponent(TailwindPanelComponent);
+      const darkComponent = darkFixture.componentInstance;
+
+      expect(darkComponent['isDarkMode']()).toBe(true);
+    });
+
+    it('SHOULD default to false when THEME_CONFIG is not provided', async () => {
+      await TestBed.resetTestingModule();
+      await TestBed.configureTestingModule({
+        imports: [TailwindPanelComponent],
+        providers: [
+          { provide: TailwindCssConverter, useValue: mockConverter },
+          { provide: CanvasService, useValue: mockCanvasService },
+        ],
+      }).compileComponents();
+
+      const noThemeFixture = TestBed.createComponent(TailwindPanelComponent);
+      const noThemeComponent = noThemeFixture.componentInstance;
+
+      expect(noThemeComponent['isDarkMode']()).toBe(false);
+    });
+  });
+});
+
+describe('TailwindPanelComponent with TestHost', () => {
+  let hostComponent: TestHostComponent;
+  let hostFixture: ComponentFixture<TestHostComponent>;
+  let mockConverter: {
+    cssToTailwind: ReturnType<typeof vi.fn>;
+    tailwindToCss: ReturnType<typeof vi.fn>;
+  };
+  let mockCanvasService: {
+    updateCss: ReturnType<typeof vi.fn>;
+    updateTailwindClasses: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(async () => {
+    mockConverter = {
+      cssToTailwind: vi.fn().mockReturnValue([]),
+      tailwindToCss: vi.fn().mockReturnValue({ css: {}, unsupportedClasses: [] }),
+    };
+
+    mockCanvasService = {
+      updateCss: vi.fn(),
+      updateTailwindClasses: vi.fn(),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [
+        { provide: TailwindCssConverter, useValue: mockConverter },
+        { provide: CanvasService, useValue: mockCanvasService },
+        { provide: THEME_CONFIG, useValue: { darkMode: false } },
+      ],
+    }).compileComponents();
+
+    hostFixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = hostFixture.componentInstance;
+  });
+
+  describe('WHEN inputs are set via host component', () => {
+    it('SHOULD update when css signal changes', async () => {
+      hostComponent.hasSelection.set(true);
+      hostComponent.compact.set(true);
+      hostFixture.detectChanges();
+
+      mockConverter.cssToTailwind.mockReturnValue(['flex']);
+
+      hostComponent.css.set({ layout: { display: 'flex' } });
+      hostFixture.detectChanges();
+      await hostFixture.whenStable();
+
+      expect(mockConverter.cssToTailwind).toHaveBeenCalled();
+    });
+
+    it('SHOULD update when tailwindClasses signal changes', async () => {
+      hostComponent.hasSelection.set(true);
+      hostComponent.compact.set(true);
+      hostFixture.detectChanges();
+
+      mockConverter.tailwindToCss.mockReturnValue({
+        css: {},
+        unsupportedClasses: ['bg-red-500'],
+      });
+
+      hostComponent.tailwindClasses.set('bg-red-500');
+      hostFixture.detectChanges();
+      await hostFixture.whenStable();
+
+      expect(mockConverter.tailwindToCss).toHaveBeenCalledWith('bg-red-500');
+    });
+
+    it('SHOULD toggle between compact and full mode', () => {
+      hostComponent.hasSelection.set(true);
+
+      hostComponent.compact.set(true);
+      hostFixture.detectChanges();
+      expect(hostFixture.nativeElement.textContent).toContain('Tailwind Classes');
+
+      hostComponent.compact.set(false);
+      hostFixture.detectChanges();
+      expect(hostFixture.nativeElement.textContent).toContain('Tailwind CSS');
+    });
+  });
+});

--- a/libs/properties/src/lib/tailwind-panel/tailwind-panel.component.ts
+++ b/libs/properties/src/lib/tailwind-panel/tailwind-panel.component.ts
@@ -1,0 +1,206 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  input,
+  signal,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import {
+  CodeEditorComponent,
+  codemirrorsHighlighter,
+  getAutocompleteTheme,
+  tailwindAutocomplete,
+  THEME_CONFIG,
+} from '@layout/shared';
+import { Css } from '@layout/models';
+import {
+  TailwindCssConverter,
+  TailwindParseResult,
+} from '@layout/serialization';
+import { CanvasService } from '@layout/canvas';
+
+/**
+ * Two-way Tailwind CSS editor panel.
+ *
+ * This component provides bidirectional sync between CSS properties and Tailwind classes:
+ * - CSS changes from the properties panel are reflected as Tailwind classes
+ * - Tailwind class edits update the CSS properties
+ *
+ * Classes that don't map to supported CSS properties (colors, typography, responsive
+ * variants, etc.) are preserved as "unsupported" classes.
+ */
+@Component({
+  selector: 'app-tailwind-panel',
+  imports: [CodeEditorComponent, FormsModule],
+  templateUrl: './tailwind-panel.component.html',
+  styleUrl: './tailwind-panel.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TailwindPanelComponent {
+  /** Current CSS from the selected canvas item */
+  css = input<Css | undefined>(undefined);
+
+  /** Current tailwindClasses from the selected canvas item (unsupported classes) */
+  tailwindClasses = input<string | undefined>(undefined);
+
+  /** Whether an item is currently selected */
+  hasSelection = input<boolean>(false);
+
+  /** Compact mode for inline use in the properties panel */
+  compact = input<boolean>(false);
+
+  private readonly converter = inject(TailwindCssConverter);
+  private readonly canvasService = inject(CanvasService);
+  private readonly themeConfig = inject(THEME_CONFIG, { optional: true });
+
+  /** Track whether we're currently updating from internal changes */
+  private isInternalUpdate = false;
+
+  /** The value displayed in the editor */
+  protected editorValue = signal<string>('');
+
+  /** Parsed unsupported classes */
+  protected unsupportedClasses = signal<string[]>([]);
+
+  /** Count of synced classes (derived from CSS) */
+  protected syncedClassCount = computed(() => {
+    return this.converter.cssToTailwind(this.css()).length;
+  });
+
+  /** Count of unsupported classes */
+  protected unsupportedClassCount = computed(() => {
+    return this.unsupportedClasses().length;
+  });
+
+  /** Dark mode from theme config */
+  protected isDarkMode = computed(() => this.themeConfig?.darkMode ?? false);
+
+  /** CodeMirror extensions for Tailwind syntax highlighting and autocomplete */
+  protected editorExtensions = computed(() => [
+    codemirrorsHighlighter(),
+    tailwindAutocomplete(),
+    getAutocompleteTheme(this.isDarkMode()),
+  ]);
+
+  constructor() {
+    // Update editor value when CSS or tailwindClasses inputs change
+    effect(() => {
+      const css = this.css();
+      const extraClasses = this.tailwindClasses() || '';
+
+      // Don't update if we're currently processing an internal change
+      if (this.isInternalUpdate) {
+        return;
+      }
+
+      // Convert CSS to Tailwind classes
+      const derivedClasses = this.converter.cssToTailwind(css);
+
+      // Parse extra classes to separate any that might now be synced
+      const extraParsed = this.converter.tailwindToCss(extraClasses);
+
+      // Combine: derived from CSS + truly unsupported from extra
+      const allClasses = [
+        ...derivedClasses,
+        ...extraParsed.unsupportedClasses,
+      ].filter(Boolean);
+
+      this.editorValue.set(allClasses.join(' '));
+      this.unsupportedClasses.set(extraParsed.unsupportedClasses);
+    });
+  }
+
+  /**
+   * Handle changes from the code editor.
+   */
+  protected onEditorChange(value: string): void {
+    this.isInternalUpdate = true;
+
+    try {
+      // Parse the Tailwind classes
+      const result: TailwindParseResult = this.converter.tailwindToCss(value);
+
+      // Update the unsupported classes display
+      this.unsupportedClasses.set(result.unsupportedClasses);
+
+      // Update the CSS properties via canvas service
+      this.updateCssFromParsedResult(result);
+
+      // Update the tailwindClasses (unsupported ones)
+      this.canvasService.updateTailwindClasses(
+        result.unsupportedClasses.join(' ')
+      );
+    } finally {
+      // Use setTimeout to ensure the flag is cleared after Angular's change detection
+      setTimeout(() => {
+        this.isInternalUpdate = false;
+      }, 0);
+    }
+  }
+
+  /**
+   * Apply parsed CSS result to the canvas.
+   */
+  private updateCssFromParsedResult(result: TailwindParseResult): void {
+    const parsedCss = result.css;
+
+    // Only update if there are actual CSS changes
+    if (Object.keys(parsedCss).length === 0) {
+      // If no synced classes, clear the CSS
+      this.canvasService.updateCss({});
+      return;
+    }
+
+    // Merge with existing CSS structure, replacing categories that were parsed
+    const currentCss = this.css() || {};
+    const mergedCss: Css = { ...currentCss };
+
+    // For each category in the parsed result, replace the entire category
+    // This ensures that removed classes also remove their CSS properties
+    for (const category of ['layout', 'spacing', 'sizing', 'flexboxGrid'] as const) {
+      if (parsedCss[category]) {
+        mergedCss[category] = parsedCss[category] as Css[typeof category];
+      } else {
+        // If the category wasn't in the parsed result, check if it should be cleared
+        // Only clear if there were previously classes for this category
+        const currentCategoryClasses = this.getCssClassesForCategory(
+          currentCss,
+          category
+        );
+        const parsedCategoryClasses = this.getCssClassesForCategory(
+          parsedCss,
+          category
+        );
+
+        if (currentCategoryClasses.length > 0 && parsedCategoryClasses.length === 0) {
+          // The category had CSS before but no longer has any synced classes
+          // Clear it by setting to empty object
+          mergedCss[category] = {} as Css[typeof category];
+        }
+      }
+    }
+
+    this.canvasService.updateCss(mergedCss);
+  }
+
+  /**
+   * Get the Tailwind classes that would be generated for a specific CSS category.
+   */
+  private getCssClassesForCategory(
+    css: Partial<Css> | undefined,
+    category: keyof Css
+  ): string[] {
+    if (!css || !css[category]) {
+      return [];
+    }
+
+    const categoryOnlyCss: Css = {
+      [category]: css[category],
+    } as Css;
+
+    return this.converter.cssToTailwind(categoryOnlyCss);
+  }
+}

--- a/libs/serialization/src/index.ts
+++ b/libs/serialization/src/index.ts
@@ -8,3 +8,5 @@ export * from './lib/serializers/css-tailwind.serializer';
 export * from './lib/serializers/serializer';
 export * from './lib/serialization.providers';
 export * from './lib/constants';
+export * from './lib/tailwind-css-converter';
+export * from './lib/tailwind-to-css-map';

--- a/libs/serialization/src/lib/serializers/css-tailwind.serializer.ts
+++ b/libs/serialization/src/lib/serializers/css-tailwind.serializer.ts
@@ -1,41 +1,36 @@
 import { CanvasItem, Css } from '@layout/models';
 import { Serializer } from './serializer';
-import { TAILWIND_DATA } from '@layout/shared';
-import { POSTFIX_UNIT, POSTFIXED_PROPERTIES } from '../constants';
+import { TailwindCssConverter } from '../tailwind-css-converter';
 
+/**
+ * Serializer that converts CSS properties to Tailwind class names.
+ *
+ * This serializer delegates to TailwindCssConverter for the actual conversion.
+ * It maintains the Serializer interface for compatibility with the serialization system.
+ *
+ * @example
+ * ```typescript
+ * const serializer = new CssTailwindSerializer();
+ * const classes = serializer.serialize([canvasItem]);
+ * // Returns: ['flex', 'gap-4', 'justify-center']
+ * ```
+ */
 export class CssTailwindSerializer extends Serializer<void> {
-  private cssToTailwindMap: Map<string, string> = new Map();
+  private converter: TailwindCssConverter;
 
-  constructor() {
+  constructor(converter?: TailwindCssConverter) {
     super();
-    this.buildReverseMap();
+    // Allow injection for testing, otherwise create a new instance
+    this.converter = converter ?? new TailwindCssConverter();
   }
 
   /**
-   * Check if a CSS value already has a unit (px, rem, em, %, etc.)
+   * Serialize a canvas item's CSS to Tailwind classes.
+   *
+   * @param items Array of canvas items (only first item is processed)
+   * @param _options Unused options parameter (for interface compatibility)
+   * @returns Array of Tailwind class names
    */
-  private hasUnit(value: string): boolean {
-    return /[a-z%]+$/i.test(value.trim());
-  }
-
-  /**
-   * Build a reverse map from CSS declarations to Tailwind class names
-   * Example: "display: flex;" -> "flex"
-   */
-  private buildReverseMap(): void {
-    const utilities = TAILWIND_DATA.utilities;
-
-    for (const utility of utilities) {
-      // Normalize the CSS detail by trimming and ensuring it ends with semicolon
-      const normalizedDetail = utility.detail.trim();
-      const cssKey = normalizedDetail.endsWith(';')
-        ? normalizedDetail.slice(0, -1).trim()
-        : normalizedDetail;
-
-      this.cssToTailwindMap.set(cssKey, utility.label);
-    }
-  }
-
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   serialize(items: CanvasItem[], _options?: void): string[] {
     if (items.length !== 1) {
@@ -47,129 +42,6 @@ export class CssTailwindSerializer extends Serializer<void> {
       return [];
     }
 
-    const tailwindClasses: string[] = [];
-
-    /* loop through the root keys (spacing, sizing, display, container,...) */
-    this.serializeItems(css, tailwindClasses);
-
-    return tailwindClasses;
-  }
-
-  private serializeItems(css: Css, tailwindClasses: string[]): void {
-    for (const key of Object.keys(css)) {
-      const value = css[key as keyof Css];
-
-      if (value == null) {
-        continue;
-      }
-
-      /* loop through the subkeys of the root keys */
-      for (const subKey of Object.keys(value)) {
-        // Convert camelCase to kebab-case for CSS property names
-        const cssPropertyName = subKey
-          .replace(/([a-z])([A-Z])/g, '$1-$2')
-          .toLowerCase();
-        const rawValue = value[subKey as keyof Css[keyof Css]];
-
-        if (rawValue == null) {
-          continue;
-        }
-
-        // Convert to string (handles both string and number values)
-        let cssPropertyValue = String(rawValue);
-
-        // Only add px postfix if the value doesn't already have a unit
-        if (POSTFIXED_PROPERTIES.includes(subKey)) {
-          if (!this.hasUnit(cssPropertyValue)) {
-            cssPropertyValue += POSTFIX_UNIT;
-          }
-        }
-
-        const tailwindClass = this.getTailwindClass(cssPropertyName, cssPropertyValue);
-        if (tailwindClass) {
-          tailwindClasses.push(tailwindClass);
-        }
-      }
-    }
-  }
-
-  /**
-   * Convert a CSS property-value pair to a Tailwind class
-   * Falls back to arbitrary value syntax if no exact match found
-   */
-  private getTailwindClass(property: string, value: string): string {
-    const cssDeclaration = `${property}: ${value}`;
-
-    // Try exact match first
-    const exactMatch = this.cssToTailwindMap.get(cssDeclaration);
-    if (exactMatch) {
-      return exactMatch;
-    }
-
-    // Fall back to arbitrary value syntax
-    return this.generateArbitraryValue(property, value);
-  }
-
-  /**
-   * Generate Tailwind arbitrary value syntax
-   * Example: "padding: 17px" -> "p-[17px]"
-   */
-  private generateArbitraryValue(property: string, value: string): string {
-    // Map CSS properties to Tailwind prefixes
-    const propertyMap: Record<string, string> = {
-      // Box Sizing
-      'padding': 'p',
-      'padding-top': 'pt',
-      'padding-right': 'pr',
-      'padding-bottom': 'pb',
-      'padding-left': 'pl',
-      'margin': 'm',
-      'margin-top': 'mt',
-      'margin-right': 'mr',
-      'margin-bottom': 'mb',
-      'margin-left': 'ml',
-      'width': 'w',
-      'height': 'h',
-      'min-width': 'min-w',
-      'min-height': 'min-h',
-      'max-width': 'max-w',
-      'max-height': 'max-h',
-
-      // Flexbox
-      'gap': 'gap',
-      'row-gap': 'gap-y',
-      'column-gap': 'gap-x',
-      'flex-direction': 'flex',
-      'flex-wrap': 'flex',
-      'justify-content': 'justify',
-      'align-items': 'items',
-      'align-content': 'content',
-      'flex': 'flex',
-      'flex-grow': 'grow',
-      'flex-shrink': 'shrink',
-      'order': 'order',
-
-      // Grid
-      'grid-template-columns': 'grid-cols',
-      'grid-template-rows': 'grid-rows',
-      'grid-column': 'col',
-      'grid-row': 'row',
-      'grid-auto-flow': 'grid-flow',
-
-      // Display (though these should be matched exactly)
-      'display': 'display',
-    };
-
-    const prefix = propertyMap[property];
-    if (prefix) {
-      // Replace spaces with underscores for valid Tailwind arbitrary values
-      const sanitizedValue = value.replace(/ /g, '_');
-      return `${prefix}-[${sanitizedValue}]`;
-    }
-
-    // If no mapping found, use the property name as-is
-    // Replace spaces with underscores for valid Tailwind arbitrary values
-    const sanitizedValue = value.replace(/ /g, '_');
-    return `[${property}:${sanitizedValue}]`;
+    return this.converter.cssToTailwind(css);
   }
 }

--- a/libs/serialization/src/lib/tailwind-css-converter.spec.ts
+++ b/libs/serialization/src/lib/tailwind-css-converter.spec.ts
@@ -1,0 +1,549 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { TailwindCssConverter, TailwindParseResult } from './tailwind-css-converter';
+import { Css } from '@layout/models';
+
+describe('TailwindCssConverter', () => {
+  let converter: TailwindCssConverter;
+
+  beforeEach(() => {
+    converter = new TailwindCssConverter();
+  });
+
+  describe('cssToTailwind', () => {
+    describe('WHEN converting layout properties', () => {
+      it('SHOULD return empty array for undefined CSS', () => {
+        const result = converter.cssToTailwind(undefined);
+        expect(result).toEqual([]);
+      });
+
+      it('SHOULD return empty array for empty CSS object', () => {
+        const result = converter.cssToTailwind({});
+        expect(result).toEqual([]);
+      });
+
+      it('SHOULD convert display: flex to "flex"', () => {
+        const css: Css = { layout: { display: 'flex' } };
+        const result = converter.cssToTailwind(css);
+        expect(result).toContain('flex');
+      });
+
+      it('SHOULD convert display: grid to "grid"', () => {
+        const css: Css = { layout: { display: 'grid' } };
+        const result = converter.cssToTailwind(css);
+        expect(result).toContain('grid');
+      });
+
+      it('SHOULD convert display: block to "block"', () => {
+        const css: Css = { layout: { display: 'block' } };
+        const result = converter.cssToTailwind(css);
+        expect(result).toContain('block');
+      });
+
+      it('SHOULD convert display: none to "hidden"', () => {
+        const css: Css = { layout: { display: 'none' } };
+        const result = converter.cssToTailwind(css);
+        expect(result).toContain('hidden');
+      });
+    });
+
+    describe('WHEN converting flexbox properties', () => {
+      it('SHOULD convert flex-direction: row to "flex-row"', () => {
+        const css: Css = { flexboxGrid: { flexDirection: 'row' } };
+        const result = converter.cssToTailwind(css);
+        expect(result).toContain('flex-row');
+      });
+
+      it('SHOULD convert flex-direction: column to "flex-col"', () => {
+        const css: Css = { flexboxGrid: { flexDirection: 'column' } };
+        const result = converter.cssToTailwind(css);
+        expect(result).toContain('flex-col');
+      });
+
+      it('SHOULD convert justify-content: center to "justify-center"', () => {
+        const css: Css = { flexboxGrid: { justifyContent: 'center' } };
+        const result = converter.cssToTailwind(css);
+        expect(result).toContain('justify-center');
+      });
+
+      it('SHOULD convert justify-content: space-between to "justify-between"', () => {
+        const css: Css = { flexboxGrid: { justifyContent: 'space-between' } };
+        const result = converter.cssToTailwind(css);
+        expect(result).toContain('justify-between');
+      });
+
+      it('SHOULD convert align-items: center to "items-center"', () => {
+        const css: Css = { flexboxGrid: { alignItems: 'center' } };
+        const result = converter.cssToTailwind(css);
+        expect(result).toContain('items-center');
+      });
+
+      it('SHOULD convert align-items: flex-start to "items-start"', () => {
+        const css: Css = { flexboxGrid: { alignItems: 'flex-start' } };
+        const result = converter.cssToTailwind(css);
+        expect(result).toContain('items-start');
+      });
+
+      it('SHOULD convert flex-wrap: wrap to "flex-wrap"', () => {
+        const css: Css = { flexboxGrid: { flexWrap: 'wrap' } };
+        const result = converter.cssToTailwind(css);
+        expect(result).toContain('flex-wrap');
+      });
+    });
+
+    describe('WHEN converting gap properties', () => {
+      it('SHOULD convert gap: 1rem to "gap-4"', () => {
+        const css: Css = { flexboxGrid: { gap: '1rem' } };
+        const result = converter.cssToTailwind(css);
+        expect(result).toContain('gap-4');
+      });
+
+      it('SHOULD convert gap: 0.5rem to "gap-2"', () => {
+        const css: Css = { flexboxGrid: { gap: '0.5rem' } };
+        const result = converter.cssToTailwind(css);
+        expect(result).toContain('gap-2');
+      });
+
+      it('SHOULD convert numeric gap to arbitrary value', () => {
+        const css: Css = { flexboxGrid: { gap: '17' } };
+        const result = converter.cssToTailwind(css);
+        expect(result).toContain('gap-[17px]');
+      });
+
+      it('SHOULD convert custom gap value to arbitrary syntax', () => {
+        const css: Css = { flexboxGrid: { gap: '13px' } };
+        const result = converter.cssToTailwind(css);
+        expect(result).toContain('gap-[13px]');
+      });
+    });
+
+    describe('WHEN converting spacing properties', () => {
+      it('SHOULD convert padding: 1rem to "p-4"', () => {
+        const css: Css = { spacing: { padding: '1rem' } };
+        const result = converter.cssToTailwind(css);
+        expect(result).toContain('p-4');
+      });
+
+      it('SHOULD convert margin: 0.5rem to "m-2"', () => {
+        const css: Css = { spacing: { margin: '0.5rem' } };
+        const result = converter.cssToTailwind(css);
+        expect(result).toContain('m-2');
+      });
+
+      it('SHOULD convert custom padding to arbitrary value', () => {
+        const css: Css = { spacing: { padding: '17px' } };
+        const result = converter.cssToTailwind(css);
+        expect(result).toContain('p-[17px]');
+      });
+
+      it('SHOULD convert custom margin to arbitrary value', () => {
+        const css: Css = { spacing: { margin: '23px' } };
+        const result = converter.cssToTailwind(css);
+        expect(result).toContain('m-[23px]');
+      });
+    });
+
+    describe('WHEN converting sizing properties', () => {
+      it('SHOULD convert width: 100% to "w-full"', () => {
+        const css: Css = { sizing: { width: '100%' } };
+        const result = converter.cssToTailwind(css);
+        expect(result).toContain('w-full');
+      });
+
+      it('SHOULD convert height: 100% to "h-full"', () => {
+        const css: Css = { sizing: { height: '100%' } };
+        const result = converter.cssToTailwind(css);
+        expect(result).toContain('h-full');
+      });
+
+      it('SHOULD convert width: auto to "w-auto"', () => {
+        const css: Css = { sizing: { width: 'auto' } };
+        const result = converter.cssToTailwind(css);
+        expect(result).toContain('w-auto');
+      });
+
+      it('SHOULD convert custom width to arbitrary value', () => {
+        const css: Css = { sizing: { width: '200px' } };
+        const result = converter.cssToTailwind(css);
+        expect(result).toContain('w-[200px]');
+      });
+    });
+
+    describe('WHEN converting grid properties', () => {
+      it('SHOULD convert grid-template-columns with spaces to underscore syntax', () => {
+        const css: Css = { flexboxGrid: { gridTemplateColumns: '1fr 1fr' } };
+        const result = converter.cssToTailwind(css);
+        expect(result).toContain('grid-cols-[1fr_1fr]');
+      });
+
+      it('SHOULD convert grid-template-rows with spaces to underscore syntax', () => {
+        const css: Css = { flexboxGrid: { gridTemplateRows: '1fr 2fr' } };
+        const result = converter.cssToTailwind(css);
+        expect(result).toContain('grid-rows-[1fr_2fr]');
+      });
+
+      it('SHOULD convert grid-auto-flow: row to "grid-flow-row"', () => {
+        const css: Css = { flexboxGrid: { gridAutoFlow: 'row' } };
+        const result = converter.cssToTailwind(css);
+        expect(result).toContain('grid-flow-row');
+      });
+
+      it('SHOULD convert grid-auto-flow: column to "grid-flow-col"', () => {
+        const css: Css = { flexboxGrid: { gridAutoFlow: 'column' } };
+        const result = converter.cssToTailwind(css);
+        expect(result).toContain('grid-flow-col');
+      });
+    });
+
+    describe('WHEN converting multiple properties', () => {
+      it('SHOULD convert all properties in a complex CSS object', () => {
+        const css: Css = {
+          layout: { display: 'flex' },
+          flexboxGrid: {
+            justifyContent: 'center',
+            alignItems: 'center',
+            gap: '1rem',
+          },
+          spacing: { padding: '1rem' },
+        };
+        const result = converter.cssToTailwind(css);
+
+        expect(result).toContain('flex');
+        expect(result).toContain('justify-center');
+        expect(result).toContain('items-center');
+        expect(result).toContain('gap-4');
+        expect(result).toContain('p-4');
+      });
+    });
+  });
+
+  describe('tailwindToCss', () => {
+    describe('WHEN parsing empty or invalid input', () => {
+      it('SHOULD return empty result for empty string', () => {
+        const result = converter.tailwindToCss('');
+        expect(result.css).toEqual({});
+        expect(result.unsupportedClasses).toEqual([]);
+      });
+
+      it('SHOULD return empty result for whitespace only', () => {
+        const result = converter.tailwindToCss('   ');
+        expect(result.css).toEqual({});
+        expect(result.unsupportedClasses).toEqual([]);
+      });
+    });
+
+    describe('WHEN parsing layout classes', () => {
+      it('SHOULD parse "flex" to display: flex', () => {
+        const result = converter.tailwindToCss('flex');
+        expect(result.css.layout?.display).toBe('flex');
+      });
+
+      it('SHOULD parse "grid" to display: grid', () => {
+        const result = converter.tailwindToCss('grid');
+        expect(result.css.layout?.display).toBe('grid');
+      });
+
+      it('SHOULD parse "block" to display: block', () => {
+        const result = converter.tailwindToCss('block');
+        expect(result.css.layout?.display).toBe('block');
+      });
+
+      it('SHOULD parse "hidden" to display: none', () => {
+        const result = converter.tailwindToCss('hidden');
+        expect(result.css.layout?.display).toBe('none');
+      });
+
+      it('SHOULD parse "inline-flex" to display: inline-flex', () => {
+        const result = converter.tailwindToCss('inline-flex');
+        expect(result.css.layout?.display).toBe('inline-flex');
+      });
+    });
+
+    describe('WHEN parsing flexbox classes', () => {
+      it('SHOULD parse "flex-row" to flex-direction: row', () => {
+        const result = converter.tailwindToCss('flex-row');
+        expect(result.css.flexboxGrid?.flexDirection).toBe('row');
+      });
+
+      it('SHOULD parse "flex-col" to flex-direction: column', () => {
+        const result = converter.tailwindToCss('flex-col');
+        expect(result.css.flexboxGrid?.flexDirection).toBe('column');
+      });
+
+      it('SHOULD parse "justify-center" to justify-content: center', () => {
+        const result = converter.tailwindToCss('justify-center');
+        expect(result.css.flexboxGrid?.justifyContent).toBe('center');
+      });
+
+      it('SHOULD parse "justify-between" to justify-content: space-between', () => {
+        const result = converter.tailwindToCss('justify-between');
+        expect(result.css.flexboxGrid?.justifyContent).toBe('space-between');
+      });
+
+      it('SHOULD parse "items-center" to align-items: center', () => {
+        const result = converter.tailwindToCss('items-center');
+        expect(result.css.flexboxGrid?.alignItems).toBe('center');
+      });
+
+      it('SHOULD parse "items-start" to align-items: flex-start', () => {
+        const result = converter.tailwindToCss('items-start');
+        expect(result.css.flexboxGrid?.alignItems).toBe('flex-start');
+      });
+
+      it('SHOULD parse "flex-wrap" to flex-wrap: wrap', () => {
+        const result = converter.tailwindToCss('flex-wrap');
+        expect(result.css.flexboxGrid?.flexWrap).toBe('wrap');
+      });
+
+      it('SHOULD parse "flex-nowrap" to flex-wrap: nowrap', () => {
+        const result = converter.tailwindToCss('flex-nowrap');
+        expect(result.css.flexboxGrid?.flexWrap).toBe('nowrap');
+      });
+    });
+
+    describe('WHEN parsing gap classes', () => {
+      it('SHOULD parse "gap-4" to gap: 1rem', () => {
+        const result = converter.tailwindToCss('gap-4');
+        expect(result.css.flexboxGrid?.gap).toBe('1rem');
+      });
+
+      it('SHOULD parse "gap-2" to gap: 0.5rem', () => {
+        const result = converter.tailwindToCss('gap-2');
+        expect(result.css.flexboxGrid?.gap).toBe('0.5rem');
+      });
+
+      it('SHOULD parse "gap-0" to gap: 0rem', () => {
+        const result = converter.tailwindToCss('gap-0');
+        expect(result.css.flexboxGrid?.gap).toBe('0rem');
+      });
+
+      it('SHOULD parse arbitrary gap "gap-[17px]"', () => {
+        const result = converter.tailwindToCss('gap-[17px]');
+        expect(result.css.flexboxGrid?.gap).toBe('17px');
+      });
+
+      it('SHOULD parse arbitrary gap "gap-[1.5rem]"', () => {
+        const result = converter.tailwindToCss('gap-[1.5rem]');
+        expect(result.css.flexboxGrid?.gap).toBe('1.5rem');
+      });
+    });
+
+    describe('WHEN parsing spacing classes', () => {
+      it('SHOULD parse "p-4" to padding: 1rem', () => {
+        const result = converter.tailwindToCss('p-4');
+        expect(result.css.spacing?.padding).toBe('1rem');
+      });
+
+      it('SHOULD parse "m-2" to margin: 0.5rem', () => {
+        const result = converter.tailwindToCss('m-2');
+        expect(result.css.spacing?.margin).toBe('0.5rem');
+      });
+
+      it('SHOULD parse "p-0" to padding: 0rem', () => {
+        const result = converter.tailwindToCss('p-0');
+        expect(result.css.spacing?.padding).toBe('0rem');
+      });
+
+      it('SHOULD parse arbitrary padding "p-[17px]"', () => {
+        const result = converter.tailwindToCss('p-[17px]');
+        expect(result.css.spacing?.padding).toBe('17px');
+      });
+
+      it('SHOULD parse arbitrary margin "m-[2rem]"', () => {
+        const result = converter.tailwindToCss('m-[2rem]');
+        expect(result.css.spacing?.margin).toBe('2rem');
+      });
+    });
+
+    describe('WHEN parsing sizing classes', () => {
+      it('SHOULD parse "w-full" to width: 100%', () => {
+        const result = converter.tailwindToCss('w-full');
+        expect(result.css.sizing?.width).toBe('100%');
+      });
+
+      it('SHOULD parse "h-full" to height: 100%', () => {
+        const result = converter.tailwindToCss('h-full');
+        expect(result.css.sizing?.height).toBe('100%');
+      });
+
+      it('SHOULD parse "w-auto" to width: auto', () => {
+        const result = converter.tailwindToCss('w-auto');
+        expect(result.css.sizing?.width).toBe('auto');
+      });
+
+      it('SHOULD parse "h-screen" to height: 100vh', () => {
+        const result = converter.tailwindToCss('h-screen');
+        expect(result.css.sizing?.height).toBe('100vh');
+      });
+
+      it('SHOULD parse arbitrary width "w-[200px]"', () => {
+        const result = converter.tailwindToCss('w-[200px]');
+        expect(result.css.sizing?.width).toBe('200px');
+      });
+
+      it('SHOULD parse arbitrary height "h-[50vh]"', () => {
+        const result = converter.tailwindToCss('h-[50vh]');
+        expect(result.css.sizing?.height).toBe('50vh');
+      });
+    });
+
+    describe('WHEN parsing grid classes', () => {
+      it('SHOULD parse "grid-flow-row" to grid-auto-flow: row', () => {
+        const result = converter.tailwindToCss('grid-flow-row');
+        expect(result.css.flexboxGrid?.gridAutoFlow).toBe('row');
+      });
+
+      it('SHOULD parse "grid-flow-col" to grid-auto-flow: column', () => {
+        const result = converter.tailwindToCss('grid-flow-col');
+        expect(result.css.flexboxGrid?.gridAutoFlow).toBe('column');
+      });
+
+      it('SHOULD parse arbitrary grid-cols "grid-cols-[1fr_1fr]"', () => {
+        const result = converter.tailwindToCss('grid-cols-[1fr_1fr]');
+        expect(result.css.flexboxGrid?.gridTemplateColumns).toBe('1fr 1fr');
+      });
+
+      it('SHOULD parse arbitrary grid-rows "grid-rows-[1fr_2fr]"', () => {
+        const result = converter.tailwindToCss('grid-rows-[1fr_2fr]');
+        expect(result.css.flexboxGrid?.gridTemplateRows).toBe('1fr 2fr');
+      });
+
+      it('SHOULD convert underscores back to spaces in arbitrary grid values', () => {
+        const result = converter.tailwindToCss('grid-cols-[1fr_2fr_1fr]');
+        expect(result.css.flexboxGrid?.gridTemplateColumns).toBe('1fr 2fr 1fr');
+      });
+    });
+
+    describe('WHEN parsing unsupported classes', () => {
+      it('SHOULD mark color classes as unsupported', () => {
+        const result = converter.tailwindToCss('bg-blue-500');
+        expect(result.unsupportedClasses).toContain('bg-blue-500');
+        expect(Object.keys(result.css)).toHaveLength(0);
+      });
+
+      it('SHOULD mark text color classes as unsupported', () => {
+        const result = converter.tailwindToCss('text-white');
+        expect(result.unsupportedClasses).toContain('text-white');
+      });
+
+      it('SHOULD mark responsive variants as unsupported', () => {
+        const result = converter.tailwindToCss('md:flex');
+        expect(result.unsupportedClasses).toContain('md:flex');
+        expect(result.css.layout?.display).toBeUndefined();
+      });
+
+      it('SHOULD mark state variants as unsupported', () => {
+        const result = converter.tailwindToCss('hover:bg-blue-500');
+        expect(result.unsupportedClasses).toContain('hover:bg-blue-500');
+      });
+
+      it('SHOULD mark dark mode variants as unsupported', () => {
+        const result = converter.tailwindToCss('dark:bg-gray-900');
+        expect(result.unsupportedClasses).toContain('dark:bg-gray-900');
+      });
+
+      it('SHOULD mark directional spacing as unsupported', () => {
+        const result = converter.tailwindToCss('px-4');
+        expect(result.unsupportedClasses).toContain('px-4');
+      });
+
+      it('SHOULD mark typography classes as unsupported', () => {
+        const result = converter.tailwindToCss('text-lg font-bold');
+        expect(result.unsupportedClasses).toContain('text-lg');
+        expect(result.unsupportedClasses).toContain('font-bold');
+      });
+    });
+
+    describe('WHEN parsing multiple classes', () => {
+      it('SHOULD parse all supported classes in a string', () => {
+        const result = converter.tailwindToCss('flex justify-center items-center gap-4');
+
+        expect(result.css.layout?.display).toBe('flex');
+        expect(result.css.flexboxGrid?.justifyContent).toBe('center');
+        expect(result.css.flexboxGrid?.alignItems).toBe('center');
+        expect(result.css.flexboxGrid?.gap).toBe('1rem');
+        expect(result.unsupportedClasses).toHaveLength(0);
+      });
+
+      it('SHOULD separate supported and unsupported classes', () => {
+        const result = converter.tailwindToCss('flex bg-blue-500 gap-4 text-white');
+
+        expect(result.css.layout?.display).toBe('flex');
+        expect(result.css.flexboxGrid?.gap).toBe('1rem');
+        expect(result.unsupportedClasses).toContain('bg-blue-500');
+        expect(result.unsupportedClasses).toContain('text-white');
+      });
+
+      it('SHOULD handle extra whitespace between classes', () => {
+        const result = converter.tailwindToCss('  flex    gap-4   items-center  ');
+
+        expect(result.css.layout?.display).toBe('flex');
+        expect(result.css.flexboxGrid?.gap).toBe('1rem');
+        expect(result.css.flexboxGrid?.alignItems).toBe('center');
+      });
+    });
+
+    describe('WHEN parsing conflicting classes', () => {
+      it('SHOULD use last value when multiple classes set same property', () => {
+        const result = converter.tailwindToCss('flex grid');
+        // Last class wins
+        expect(result.css.layout?.display).toBe('grid');
+      });
+
+      it('SHOULD use last gap value when multiple gap classes present', () => {
+        const result = converter.tailwindToCss('gap-2 gap-4');
+        expect(result.css.flexboxGrid?.gap).toBe('1rem');
+      });
+    });
+  });
+
+  describe('bidirectional consistency', () => {
+    describe('WHEN round-tripping CSS through Tailwind and back', () => {
+      it('SHOULD preserve display: flex', () => {
+        const originalCss: Css = { layout: { display: 'flex' } };
+        const tailwind = converter.cssToTailwind(originalCss);
+        const result = converter.tailwindToCss(tailwind.join(' '));
+
+        expect(result.css.layout?.display).toBe('flex');
+      });
+
+      it('SHOULD preserve complex CSS through round-trip', () => {
+        const originalCss: Css = {
+          layout: { display: 'flex' },
+          flexboxGrid: {
+            justifyContent: 'center',
+            alignItems: 'center',
+            gap: '1rem',
+          },
+        };
+
+        const tailwind = converter.cssToTailwind(originalCss);
+        const result = converter.tailwindToCss(tailwind.join(' '));
+
+        expect(result.css.layout?.display).toBe('flex');
+        expect(result.css.flexboxGrid?.justifyContent).toBe('center');
+        expect(result.css.flexboxGrid?.alignItems).toBe('center');
+        expect(result.css.flexboxGrid?.gap).toBe('1rem');
+      });
+    });
+
+    describe('WHEN round-tripping Tailwind through CSS and back', () => {
+      it('SHOULD preserve basic class string', () => {
+        const original = 'flex justify-center items-center';
+        const result = converter.tailwindToCss(original);
+        const tailwind = converter.cssToTailwind(result.css as Css);
+
+        expect(tailwind).toContain('flex');
+        expect(tailwind).toContain('justify-center');
+        expect(tailwind).toContain('items-center');
+      });
+
+      it('SHOULD preserve gap-4 class', () => {
+        const original = 'gap-4';
+        const result = converter.tailwindToCss(original);
+        const tailwind = converter.cssToTailwind(result.css as Css);
+
+        expect(tailwind).toContain('gap-4');
+      });
+    });
+  });
+});

--- a/libs/serialization/src/lib/tailwind-css-converter.ts
+++ b/libs/serialization/src/lib/tailwind-css-converter.ts
@@ -1,0 +1,416 @@
+import { Injectable } from '@angular/core';
+import { Css } from '@layout/models';
+import { TAILWIND_DATA } from '@layout/shared';
+import {
+  TAILWIND_TO_CSS_MAP,
+  CSS_PROPERTY_TO_TAILWIND_PREFIX,
+  TailwindToCssMapping,
+  buildCssToTailwindMap,
+} from './tailwind-to-css-map';
+import { POSTFIX_UNIT, POSTFIXED_PROPERTIES } from './constants';
+
+/**
+ * Result of parsing a Tailwind class string.
+ */
+export interface TailwindParseResult {
+  /** CSS properties extracted from supported Tailwind classes */
+  css: Partial<Css>;
+  /** Classes that couldn't be mapped to CSS properties (variants, unsupported utilities, etc.) */
+  unsupportedClasses: string[];
+}
+
+/**
+ * Patterns for parsing arbitrary value Tailwind classes.
+ * Example: gap-[17px], w-[200px], p-[1.5rem]
+ */
+interface ArbitraryValuePattern {
+  /** Regex pattern to match the class */
+  pattern: RegExp;
+  /** CSS category in the Css interface */
+  category: keyof Css;
+  /** CSS property name (camelCase) */
+  property: string;
+}
+
+const ARBITRARY_VALUE_PATTERNS: ArbitraryValuePattern[] = [
+  // Spacing
+  { pattern: /^p-\[(.+)\]$/, category: 'spacing', property: 'padding' },
+  { pattern: /^m-\[(.+)\]$/, category: 'spacing', property: 'margin' },
+
+  // Sizing
+  { pattern: /^w-\[(.+)\]$/, category: 'sizing', property: 'width' },
+  { pattern: /^h-\[(.+)\]$/, category: 'sizing', property: 'height' },
+
+  // FlexboxGrid
+  { pattern: /^gap-\[(.+)\]$/, category: 'flexboxGrid', property: 'gap' },
+  { pattern: /^basis-\[(.+)\]$/, category: 'flexboxGrid', property: 'flexBasis' },
+  { pattern: /^grow-\[(.+)\]$/, category: 'flexboxGrid', property: 'flexGrow' },
+  { pattern: /^shrink-\[(.+)\]$/, category: 'flexboxGrid', property: 'flexShrink' },
+  { pattern: /^grid-cols-\[(.+)\]$/, category: 'flexboxGrid', property: 'gridTemplateColumns' },
+  { pattern: /^grid-rows-\[(.+)\]$/, category: 'flexboxGrid', property: 'gridTemplateRows' },
+  { pattern: /^col-\[(.+)\]$/, category: 'flexboxGrid', property: 'gridColumn' },
+  { pattern: /^row-\[(.+)\]$/, category: 'flexboxGrid', property: 'gridRow' },
+  { pattern: /^col-start-\[(.+)\]$/, category: 'flexboxGrid', property: 'gridColumnStart' },
+  { pattern: /^col-end-\[(.+)\]$/, category: 'flexboxGrid', property: 'gridColumnEnd' },
+  { pattern: /^row-start-\[(.+)\]$/, category: 'flexboxGrid', property: 'gridRowStart' },
+  { pattern: /^row-end-\[(.+)\]$/, category: 'flexboxGrid', property: 'gridRowEnd' },
+  { pattern: /^auto-cols-\[(.+)\]$/, category: 'flexboxGrid', property: 'gridAutoColumns' },
+  { pattern: /^auto-rows-\[(.+)\]$/, category: 'flexboxGrid', property: 'gridAutoRows' },
+];
+
+/**
+ * Bidirectional converter between CSS properties and Tailwind classes.
+ *
+ * This service provides two-way conversion:
+ * - `cssToTailwind()`: Convert CSS model properties to Tailwind class names
+ * - `tailwindToCss()`: Parse Tailwind class string into CSS model properties
+ *
+ * Only properties defined in the Css interface are supported. Unsupported
+ * Tailwind classes (colors, typography, responsive variants, etc.) are
+ * returned separately for preservation.
+ */
+@Injectable({ providedIn: 'root' })
+export class TailwindCssConverter {
+  /** Map from CSS declarations to Tailwind classes (built from TAILWIND_DATA) */
+  private cssDeclarationToTailwindMap: Map<string, string> = new Map();
+
+  /** Map from "category.property:value" to Tailwind class */
+  private cssToTailwindMap: Map<string, string>;
+
+  constructor() {
+    this.buildCssDeclarationMap();
+    this.cssToTailwindMap = buildCssToTailwindMap();
+  }
+
+  /**
+   * Convert CSS model to Tailwind classes.
+   *
+   * @param css The CSS model object
+   * @returns Array of Tailwind class names
+   *
+   * @example
+   * ```typescript
+   * const classes = converter.cssToTailwind({
+   *   layout: { display: 'flex' },
+   *   flexboxGrid: { gap: '1rem', justifyContent: 'center' }
+   * });
+   * // Returns: ['flex', 'gap-4', 'justify-center']
+   * ```
+   */
+  cssToTailwind(css: Css | undefined): string[] {
+    if (!css) {
+      return [];
+    }
+
+    const tailwindClasses: string[] = [];
+
+    // Iterate through categories (layout, spacing, sizing, flexboxGrid)
+    for (const category of Object.keys(css) as (keyof Css)[]) {
+      const categoryValue = css[category];
+      if (categoryValue == null) {
+        continue;
+      }
+
+      // Iterate through properties within the category
+      for (const property of Object.keys(categoryValue)) {
+        const rawValue = (categoryValue as Record<string, unknown>)[property];
+        if (rawValue == null) {
+          continue;
+        }
+
+        const tailwindClass = this.convertPropertyToTailwind(
+          category,
+          property,
+          rawValue
+        );
+        if (tailwindClass) {
+          tailwindClasses.push(tailwindClass);
+        }
+      }
+    }
+
+    return tailwindClasses;
+  }
+
+  /**
+   * Parse a Tailwind class string into CSS model properties.
+   *
+   * @param classString Space-separated Tailwind classes
+   * @returns Object containing parsed CSS and unsupported classes
+   *
+   * @example
+   * ```typescript
+   * const result = converter.tailwindToCss('flex gap-4 justify-center bg-blue-500');
+   * // Returns: {
+   * //   css: {
+   * //     layout: { display: 'flex' },
+   * //     flexboxGrid: { gap: '1rem', justifyContent: 'center' }
+   * //   },
+   * //   unsupportedClasses: ['bg-blue-500']
+   * // }
+   * ```
+   */
+  tailwindToCss(classString: string): TailwindParseResult {
+    const css: Partial<Css> = {};
+    const unsupportedClasses: string[] = [];
+
+    if (!classString || !classString.trim()) {
+      return { css, unsupportedClasses };
+    }
+
+    const classes = classString.trim().split(/\s+/).filter(Boolean);
+
+    for (const className of classes) {
+      // Skip classes with variant prefixes (responsive, state, etc.)
+      if (this.hasVariantPrefix(className)) {
+        unsupportedClasses.push(className);
+        continue;
+      }
+
+      // Try to parse the class
+      const mapping = this.parseClass(className);
+
+      if (mapping) {
+        // Apply the mapping to the CSS object
+        this.applyMapping(css, mapping);
+      } else {
+        unsupportedClasses.push(className);
+      }
+    }
+
+    return { css, unsupportedClasses };
+  }
+
+  /**
+   * Build the CSS declaration to Tailwind map from TAILWIND_DATA.
+   * Example: "display: flex" -> "flex"
+   */
+  private buildCssDeclarationMap(): void {
+    const utilities = TAILWIND_DATA.utilities;
+
+    for (const utility of utilities) {
+      const normalizedDetail = utility.detail.trim();
+      const cssKey = normalizedDetail.endsWith(';')
+        ? normalizedDetail.slice(0, -1).trim()
+        : normalizedDetail;
+
+      this.cssDeclarationToTailwindMap.set(cssKey, utility.label);
+    }
+  }
+
+  /**
+   * Convert a single CSS property to a Tailwind class.
+   */
+  private convertPropertyToTailwind(
+    category: keyof Css,
+    property: string,
+    rawValue: unknown
+  ): string | null {
+    // Convert to string
+    let valueStr = String(rawValue);
+
+    // Handle postfixed properties (e.g., gap needs 'px' suffix for numeric values)
+    if (POSTFIXED_PROPERTIES.includes(property) && !this.hasUnit(valueStr)) {
+      valueStr += POSTFIX_UNIT;
+    }
+
+    // Try exact match first using our curated map
+    const mapKey = `${category}.${property}:${valueStr}`;
+    const exactMatch = this.cssToTailwindMap.get(mapKey);
+    if (exactMatch) {
+      return exactMatch;
+    }
+
+    // Try CSS declaration match (from TAILWIND_DATA)
+    const cssPropertyName = this.camelToKebab(property);
+    const cssDeclaration = `${cssPropertyName}: ${valueStr}`;
+    const declarationMatch = this.cssDeclarationToTailwindMap.get(cssDeclaration);
+    if (declarationMatch) {
+      return declarationMatch;
+    }
+
+    // Fall back to arbitrary value syntax
+    return this.generateArbitraryValue(cssPropertyName, valueStr);
+  }
+
+  /**
+   * Parse a Tailwind class into a CSS mapping.
+   */
+  private parseClass(className: string): TailwindToCssMapping | null {
+    // Try exact match from our map
+    const exactMapping = TAILWIND_TO_CSS_MAP[className];
+    if (exactMapping) {
+      return exactMapping;
+    }
+
+    // Try arbitrary value patterns
+    const arbitraryMapping = this.parseArbitraryValue(className);
+    if (arbitraryMapping) {
+      return arbitraryMapping;
+    }
+
+    return null;
+  }
+
+  /**
+   * Parse arbitrary value syntax (e.g., gap-[17px], w-[200px]).
+   */
+  private parseArbitraryValue(className: string): TailwindToCssMapping | null {
+    for (const pattern of ARBITRARY_VALUE_PATTERNS) {
+      const match = className.match(pattern.pattern);
+      if (match) {
+        // Convert underscores back to spaces (Tailwind arbitrary value syntax)
+        const value = match[1].replace(/_/g, ' ');
+        return {
+          category: pattern.category,
+          property: pattern.property,
+          value,
+        };
+      }
+    }
+
+    // Handle generic arbitrary property syntax: [property:value]
+    const genericMatch = className.match(/^\[([a-z-]+):(.+)\]$/);
+    if (genericMatch) {
+      const cssProperty = genericMatch[1];
+      const value = genericMatch[2].replace(/_/g, ' ');
+      const mapping = this.findCategoryForProperty(cssProperty);
+      if (mapping) {
+        return {
+          category: mapping.category,
+          property: mapping.property,
+          value,
+        };
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Find the CSS category for a kebab-case CSS property name.
+   */
+  private findCategoryForProperty(
+    cssProperty: string
+  ): { category: keyof Css; property: string } | null {
+    // Convert kebab-case to camelCase
+    const camelProperty = this.kebabToCamel(cssProperty);
+
+    // Check each category
+    const categoryPropertyMap: Record<keyof Css, string[]> = {
+      layout: ['display'],
+      spacing: ['padding', 'margin'],
+      sizing: ['width', 'height'],
+      flexboxGrid: [
+        'gap', 'justifyContent', 'alignItems', 'alignContent', 'justifyItems',
+        'placeItems', 'flexDirection', 'flexWrap', 'flexGrow', 'flexShrink',
+        'flexBasis', 'alignSelf', 'gridTemplateColumns', 'gridTemplateRows',
+        'gridTemplateAreas', 'gridAutoFlow', 'gridAutoColumns', 'gridAutoRows',
+        'gridColumn', 'gridRow', 'gridArea', 'gridColumnStart', 'gridColumnEnd',
+        'gridRowStart', 'gridRowEnd', 'justifySelf',
+      ],
+    };
+
+    for (const [category, properties] of Object.entries(categoryPropertyMap)) {
+      if (properties.includes(camelProperty)) {
+        return { category: category as keyof Css, property: camelProperty };
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Apply a mapping to the CSS object, creating nested structure as needed.
+   */
+  private applyMapping(css: Partial<Css>, mapping: TailwindToCssMapping): void {
+    if (!css[mapping.category]) {
+      css[mapping.category] = {} as Css[keyof Css];
+    }
+
+    (css[mapping.category] as Record<string, unknown>)[mapping.property] = mapping.value;
+  }
+
+  /**
+   * Check if a class has a variant prefix (responsive, state, dark, etc.).
+   */
+  private hasVariantPrefix(className: string): boolean {
+    // Variant prefixes contain a colon before the utility name
+    // Examples: md:flex, hover:bg-blue-500, dark:text-white
+    return className.includes(':');
+  }
+
+  /**
+   * Check if a CSS value already has a unit.
+   */
+  private hasUnit(value: string): boolean {
+    return /[a-z%]+$/i.test(value.trim());
+  }
+
+  /**
+   * Convert camelCase to kebab-case.
+   */
+  private camelToKebab(str: string): string {
+    return str.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+  }
+
+  /**
+   * Convert kebab-case to camelCase.
+   */
+  private kebabToCamel(str: string): string {
+    return str.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+  }
+
+  /**
+   * Generate Tailwind arbitrary value syntax for properties without exact matches.
+   */
+  private generateArbitraryValue(property: string, value: string): string {
+    const propertyMap: Record<string, string> = {
+      'padding': 'p',
+      'padding-top': 'pt',
+      'padding-right': 'pr',
+      'padding-bottom': 'pb',
+      'padding-left': 'pl',
+      'margin': 'm',
+      'margin-top': 'mt',
+      'margin-right': 'mr',
+      'margin-bottom': 'mb',
+      'margin-left': 'ml',
+      'width': 'w',
+      'height': 'h',
+      'min-width': 'min-w',
+      'min-height': 'min-h',
+      'max-width': 'max-w',
+      'max-height': 'max-h',
+      'gap': 'gap',
+      'row-gap': 'gap-y',
+      'column-gap': 'gap-x',
+      'flex-direction': 'flex',
+      'flex-wrap': 'flex',
+      'justify-content': 'justify',
+      'align-items': 'items',
+      'align-content': 'content',
+      'flex': 'flex',
+      'flex-grow': 'grow',
+      'flex-shrink': 'shrink',
+      'flex-basis': 'basis',
+      'order': 'order',
+      'grid-template-columns': 'grid-cols',
+      'grid-template-rows': 'grid-rows',
+      'grid-column': 'col',
+      'grid-row': 'row',
+      'grid-auto-flow': 'grid-flow',
+      'display': 'display',
+    };
+
+    const prefix = propertyMap[property];
+    const sanitizedValue = value.replace(/ /g, '_');
+
+    if (prefix) {
+      return `${prefix}-[${sanitizedValue}]`;
+    }
+
+    // Generic arbitrary property syntax
+    return `[${property}:${sanitizedValue}]`;
+  }
+}

--- a/libs/serialization/src/lib/tailwind-to-css-map.ts
+++ b/libs/serialization/src/lib/tailwind-to-css-map.ts
@@ -1,0 +1,595 @@
+import { Css } from '@layout/models';
+
+/**
+ * Mapping from a Tailwind class to its corresponding CSS model property.
+ */
+export interface TailwindToCssMapping {
+  /** The category in the Css interface (layout, spacing, sizing, flexboxGrid) */
+  category: keyof Css;
+  /** The property name within the category (camelCase) */
+  property: string;
+  /** The CSS value to set */
+  value: string | number;
+}
+
+/**
+ * CSS property to Tailwind prefix mapping for arbitrary values.
+ * Used to parse classes like `gap-[17px]` back to CSS.
+ */
+export const CSS_PROPERTY_TO_TAILWIND_PREFIX: Record<string, { category: keyof Css; property: string }> = {
+  // Spacing
+  'p': { category: 'spacing', property: 'padding' },
+  'm': { category: 'spacing', property: 'margin' },
+
+  // Sizing
+  'w': { category: 'sizing', property: 'width' },
+  'h': { category: 'sizing', property: 'height' },
+
+  // FlexboxGrid
+  'gap': { category: 'flexboxGrid', property: 'gap' },
+  'justify': { category: 'flexboxGrid', property: 'justifyContent' },
+  'items': { category: 'flexboxGrid', property: 'alignItems' },
+  'content': { category: 'flexboxGrid', property: 'alignContent' },
+  'self': { category: 'flexboxGrid', property: 'alignSelf' },
+  'justify-self': { category: 'flexboxGrid', property: 'justifySelf' },
+  'justify-items': { category: 'flexboxGrid', property: 'justifyItems' },
+  'grow': { category: 'flexboxGrid', property: 'flexGrow' },
+  'shrink': { category: 'flexboxGrid', property: 'flexShrink' },
+  'basis': { category: 'flexboxGrid', property: 'flexBasis' },
+  'grid-cols': { category: 'flexboxGrid', property: 'gridTemplateColumns' },
+  'grid-rows': { category: 'flexboxGrid', property: 'gridTemplateRows' },
+  'col': { category: 'flexboxGrid', property: 'gridColumn' },
+  'row': { category: 'flexboxGrid', property: 'gridRow' },
+  'col-start': { category: 'flexboxGrid', property: 'gridColumnStart' },
+  'col-end': { category: 'flexboxGrid', property: 'gridColumnEnd' },
+  'row-start': { category: 'flexboxGrid', property: 'gridRowStart' },
+  'row-end': { category: 'flexboxGrid', property: 'gridRowEnd' },
+  'grid-flow': { category: 'flexboxGrid', property: 'gridAutoFlow' },
+  'auto-cols': { category: 'flexboxGrid', property: 'gridAutoColumns' },
+  'auto-rows': { category: 'flexboxGrid', property: 'gridAutoRows' },
+};
+
+/**
+ * Mapping from Tailwind utility classes to CSS model properties.
+ * Only includes classes that map to properties in our Css interface.
+ *
+ * Note: Directional classes (px-*, py-*, pt-*, etc.) and responsive variants
+ * (md:*, lg:*, etc.) are NOT included as they don't map 1:1 to our CSS model.
+ */
+export const TAILWIND_TO_CSS_MAP: Record<string, TailwindToCssMapping> = {
+  // ============================================
+  // DISPLAY (layout.display)
+  // ============================================
+  'block': { category: 'layout', property: 'display', value: 'block' },
+  'inline-block': { category: 'layout', property: 'display', value: 'inline-block' },
+  'inline': { category: 'layout', property: 'display', value: 'inline' },
+  'flex': { category: 'layout', property: 'display', value: 'flex' },
+  'inline-flex': { category: 'layout', property: 'display', value: 'inline-flex' },
+  'grid': { category: 'layout', property: 'display', value: 'grid' },
+  'inline-grid': { category: 'layout', property: 'display', value: 'inline-grid' },
+  'contents': { category: 'layout', property: 'display', value: 'contents' },
+  'flow-root': { category: 'layout', property: 'display', value: 'flow-root' },
+  'hidden': { category: 'layout', property: 'display', value: 'none' },
+
+  // ============================================
+  // PADDING (spacing.padding) - shorthand only
+  // ============================================
+  'p-0': { category: 'spacing', property: 'padding', value: '0rem' },
+  'p-0.5': { category: 'spacing', property: 'padding', value: '0.125rem' },
+  'p-1': { category: 'spacing', property: 'padding', value: '0.25rem' },
+  'p-1.5': { category: 'spacing', property: 'padding', value: '0.375rem' },
+  'p-2': { category: 'spacing', property: 'padding', value: '0.5rem' },
+  'p-2.5': { category: 'spacing', property: 'padding', value: '0.625rem' },
+  'p-3': { category: 'spacing', property: 'padding', value: '0.75rem' },
+  'p-3.5': { category: 'spacing', property: 'padding', value: '0.875rem' },
+  'p-4': { category: 'spacing', property: 'padding', value: '1rem' },
+  'p-5': { category: 'spacing', property: 'padding', value: '1.25rem' },
+  'p-6': { category: 'spacing', property: 'padding', value: '1.5rem' },
+  'p-7': { category: 'spacing', property: 'padding', value: '1.75rem' },
+  'p-8': { category: 'spacing', property: 'padding', value: '2rem' },
+  'p-9': { category: 'spacing', property: 'padding', value: '2.25rem' },
+  'p-10': { category: 'spacing', property: 'padding', value: '2.5rem' },
+  'p-11': { category: 'spacing', property: 'padding', value: '2.75rem' },
+  'p-12': { category: 'spacing', property: 'padding', value: '3rem' },
+  'p-14': { category: 'spacing', property: 'padding', value: '3.5rem' },
+  'p-16': { category: 'spacing', property: 'padding', value: '4rem' },
+  'p-20': { category: 'spacing', property: 'padding', value: '5rem' },
+  'p-24': { category: 'spacing', property: 'padding', value: '6rem' },
+  'p-28': { category: 'spacing', property: 'padding', value: '7rem' },
+  'p-32': { category: 'spacing', property: 'padding', value: '8rem' },
+  'p-36': { category: 'spacing', property: 'padding', value: '9rem' },
+  'p-40': { category: 'spacing', property: 'padding', value: '10rem' },
+  'p-44': { category: 'spacing', property: 'padding', value: '11rem' },
+  'p-48': { category: 'spacing', property: 'padding', value: '12rem' },
+  'p-52': { category: 'spacing', property: 'padding', value: '13rem' },
+  'p-56': { category: 'spacing', property: 'padding', value: '14rem' },
+  'p-60': { category: 'spacing', property: 'padding', value: '15rem' },
+  'p-64': { category: 'spacing', property: 'padding', value: '16rem' },
+  'p-72': { category: 'spacing', property: 'padding', value: '18rem' },
+  'p-80': { category: 'spacing', property: 'padding', value: '20rem' },
+  'p-96': { category: 'spacing', property: 'padding', value: '24rem' },
+  'p-px': { category: 'spacing', property: 'padding', value: '1px' },
+
+  // ============================================
+  // MARGIN (spacing.margin) - shorthand only
+  // ============================================
+  'm-0': { category: 'spacing', property: 'margin', value: '0rem' },
+  'm-0.5': { category: 'spacing', property: 'margin', value: '0.125rem' },
+  'm-1': { category: 'spacing', property: 'margin', value: '0.25rem' },
+  'm-1.5': { category: 'spacing', property: 'margin', value: '0.375rem' },
+  'm-2': { category: 'spacing', property: 'margin', value: '0.5rem' },
+  'm-2.5': { category: 'spacing', property: 'margin', value: '0.625rem' },
+  'm-3': { category: 'spacing', property: 'margin', value: '0.75rem' },
+  'm-3.5': { category: 'spacing', property: 'margin', value: '0.875rem' },
+  'm-4': { category: 'spacing', property: 'margin', value: '1rem' },
+  'm-5': { category: 'spacing', property: 'margin', value: '1.25rem' },
+  'm-6': { category: 'spacing', property: 'margin', value: '1.5rem' },
+  'm-7': { category: 'spacing', property: 'margin', value: '1.75rem' },
+  'm-8': { category: 'spacing', property: 'margin', value: '2rem' },
+  'm-9': { category: 'spacing', property: 'margin', value: '2.25rem' },
+  'm-10': { category: 'spacing', property: 'margin', value: '2.5rem' },
+  'm-11': { category: 'spacing', property: 'margin', value: '2.75rem' },
+  'm-12': { category: 'spacing', property: 'margin', value: '3rem' },
+  'm-14': { category: 'spacing', property: 'margin', value: '3.5rem' },
+  'm-16': { category: 'spacing', property: 'margin', value: '4rem' },
+  'm-20': { category: 'spacing', property: 'margin', value: '5rem' },
+  'm-24': { category: 'spacing', property: 'margin', value: '6rem' },
+  'm-auto': { category: 'spacing', property: 'margin', value: 'auto' },
+  'm-px': { category: 'spacing', property: 'margin', value: '1px' },
+
+  // ============================================
+  // WIDTH (sizing.width)
+  // ============================================
+  'w-0': { category: 'sizing', property: 'width', value: '0' },
+  'w-px': { category: 'sizing', property: 'width', value: '1px' },
+  'w-0.5': { category: 'sizing', property: 'width', value: '0.125rem' },
+  'w-1': { category: 'sizing', property: 'width', value: '0.25rem' },
+  'w-1.5': { category: 'sizing', property: 'width', value: '0.375rem' },
+  'w-2': { category: 'sizing', property: 'width', value: '0.5rem' },
+  'w-2.5': { category: 'sizing', property: 'width', value: '0.625rem' },
+  'w-3': { category: 'sizing', property: 'width', value: '0.75rem' },
+  'w-3.5': { category: 'sizing', property: 'width', value: '0.875rem' },
+  'w-4': { category: 'sizing', property: 'width', value: '1rem' },
+  'w-5': { category: 'sizing', property: 'width', value: '1.25rem' },
+  'w-6': { category: 'sizing', property: 'width', value: '1.5rem' },
+  'w-7': { category: 'sizing', property: 'width', value: '1.75rem' },
+  'w-8': { category: 'sizing', property: 'width', value: '2rem' },
+  'w-9': { category: 'sizing', property: 'width', value: '2.25rem' },
+  'w-10': { category: 'sizing', property: 'width', value: '2.5rem' },
+  'w-11': { category: 'sizing', property: 'width', value: '2.75rem' },
+  'w-12': { category: 'sizing', property: 'width', value: '3rem' },
+  'w-14': { category: 'sizing', property: 'width', value: '3.5rem' },
+  'w-16': { category: 'sizing', property: 'width', value: '4rem' },
+  'w-20': { category: 'sizing', property: 'width', value: '5rem' },
+  'w-24': { category: 'sizing', property: 'width', value: '6rem' },
+  'w-28': { category: 'sizing', property: 'width', value: '7rem' },
+  'w-32': { category: 'sizing', property: 'width', value: '8rem' },
+  'w-36': { category: 'sizing', property: 'width', value: '9rem' },
+  'w-40': { category: 'sizing', property: 'width', value: '10rem' },
+  'w-44': { category: 'sizing', property: 'width', value: '11rem' },
+  'w-48': { category: 'sizing', property: 'width', value: '12rem' },
+  'w-52': { category: 'sizing', property: 'width', value: '13rem' },
+  'w-56': { category: 'sizing', property: 'width', value: '14rem' },
+  'w-60': { category: 'sizing', property: 'width', value: '15rem' },
+  'w-64': { category: 'sizing', property: 'width', value: '16rem' },
+  'w-72': { category: 'sizing', property: 'width', value: '18rem' },
+  'w-80': { category: 'sizing', property: 'width', value: '20rem' },
+  'w-96': { category: 'sizing', property: 'width', value: '24rem' },
+  'w-auto': { category: 'sizing', property: 'width', value: 'auto' },
+  'w-full': { category: 'sizing', property: 'width', value: '100%' },
+  'w-screen': { category: 'sizing', property: 'width', value: '100vw' },
+  'w-min': { category: 'sizing', property: 'width', value: 'min-content' },
+  'w-max': { category: 'sizing', property: 'width', value: 'max-content' },
+  'w-fit': { category: 'sizing', property: 'width', value: 'fit-content' },
+  'w-1/2': { category: 'sizing', property: 'width', value: '50%' },
+  'w-1/3': { category: 'sizing', property: 'width', value: '33.333333%' },
+  'w-2/3': { category: 'sizing', property: 'width', value: '66.666667%' },
+  'w-1/4': { category: 'sizing', property: 'width', value: '25%' },
+  'w-2/4': { category: 'sizing', property: 'width', value: '50%' },
+  'w-3/4': { category: 'sizing', property: 'width', value: '75%' },
+  'w-1/5': { category: 'sizing', property: 'width', value: '20%' },
+  'w-2/5': { category: 'sizing', property: 'width', value: '40%' },
+  'w-3/5': { category: 'sizing', property: 'width', value: '60%' },
+  'w-4/5': { category: 'sizing', property: 'width', value: '80%' },
+  'w-1/6': { category: 'sizing', property: 'width', value: '16.666667%' },
+  'w-5/6': { category: 'sizing', property: 'width', value: '83.333333%' },
+
+  // ============================================
+  // HEIGHT (sizing.height)
+  // ============================================
+  'h-0': { category: 'sizing', property: 'height', value: '0' },
+  'h-px': { category: 'sizing', property: 'height', value: '1px' },
+  'h-0.5': { category: 'sizing', property: 'height', value: '0.125rem' },
+  'h-1': { category: 'sizing', property: 'height', value: '0.25rem' },
+  'h-1.5': { category: 'sizing', property: 'height', value: '0.375rem' },
+  'h-2': { category: 'sizing', property: 'height', value: '0.5rem' },
+  'h-2.5': { category: 'sizing', property: 'height', value: '0.625rem' },
+  'h-3': { category: 'sizing', property: 'height', value: '0.75rem' },
+  'h-3.5': { category: 'sizing', property: 'height', value: '0.875rem' },
+  'h-4': { category: 'sizing', property: 'height', value: '1rem' },
+  'h-5': { category: 'sizing', property: 'height', value: '1.25rem' },
+  'h-6': { category: 'sizing', property: 'height', value: '1.5rem' },
+  'h-7': { category: 'sizing', property: 'height', value: '1.75rem' },
+  'h-8': { category: 'sizing', property: 'height', value: '2rem' },
+  'h-9': { category: 'sizing', property: 'height', value: '2.25rem' },
+  'h-10': { category: 'sizing', property: 'height', value: '2.5rem' },
+  'h-11': { category: 'sizing', property: 'height', value: '2.75rem' },
+  'h-12': { category: 'sizing', property: 'height', value: '3rem' },
+  'h-14': { category: 'sizing', property: 'height', value: '3.5rem' },
+  'h-16': { category: 'sizing', property: 'height', value: '4rem' },
+  'h-20': { category: 'sizing', property: 'height', value: '5rem' },
+  'h-24': { category: 'sizing', property: 'height', value: '6rem' },
+  'h-28': { category: 'sizing', property: 'height', value: '7rem' },
+  'h-32': { category: 'sizing', property: 'height', value: '8rem' },
+  'h-36': { category: 'sizing', property: 'height', value: '9rem' },
+  'h-40': { category: 'sizing', property: 'height', value: '10rem' },
+  'h-44': { category: 'sizing', property: 'height', value: '11rem' },
+  'h-48': { category: 'sizing', property: 'height', value: '12rem' },
+  'h-52': { category: 'sizing', property: 'height', value: '13rem' },
+  'h-56': { category: 'sizing', property: 'height', value: '14rem' },
+  'h-60': { category: 'sizing', property: 'height', value: '15rem' },
+  'h-64': { category: 'sizing', property: 'height', value: '16rem' },
+  'h-72': { category: 'sizing', property: 'height', value: '18rem' },
+  'h-80': { category: 'sizing', property: 'height', value: '20rem' },
+  'h-96': { category: 'sizing', property: 'height', value: '24rem' },
+  'h-auto': { category: 'sizing', property: 'height', value: 'auto' },
+  'h-full': { category: 'sizing', property: 'height', value: '100%' },
+  'h-screen': { category: 'sizing', property: 'height', value: '100vh' },
+  'h-min': { category: 'sizing', property: 'height', value: 'min-content' },
+  'h-max': { category: 'sizing', property: 'height', value: 'max-content' },
+  'h-fit': { category: 'sizing', property: 'height', value: 'fit-content' },
+  'h-1/2': { category: 'sizing', property: 'height', value: '50%' },
+  'h-1/3': { category: 'sizing', property: 'height', value: '33.333333%' },
+  'h-2/3': { category: 'sizing', property: 'height', value: '66.666667%' },
+  'h-1/4': { category: 'sizing', property: 'height', value: '25%' },
+  'h-2/4': { category: 'sizing', property: 'height', value: '50%' },
+  'h-3/4': { category: 'sizing', property: 'height', value: '75%' },
+  'h-1/5': { category: 'sizing', property: 'height', value: '20%' },
+  'h-2/5': { category: 'sizing', property: 'height', value: '40%' },
+  'h-3/5': { category: 'sizing', property: 'height', value: '60%' },
+  'h-4/5': { category: 'sizing', property: 'height', value: '80%' },
+  'h-1/6': { category: 'sizing', property: 'height', value: '16.666667%' },
+  'h-5/6': { category: 'sizing', property: 'height', value: '83.333333%' },
+
+  // ============================================
+  // GAP (flexboxGrid.gap)
+  // ============================================
+  'gap-0': { category: 'flexboxGrid', property: 'gap', value: '0rem' },
+  'gap-0.5': { category: 'flexboxGrid', property: 'gap', value: '0.125rem' },
+  'gap-1': { category: 'flexboxGrid', property: 'gap', value: '0.25rem' },
+  'gap-1.5': { category: 'flexboxGrid', property: 'gap', value: '0.375rem' },
+  'gap-2': { category: 'flexboxGrid', property: 'gap', value: '0.5rem' },
+  'gap-2.5': { category: 'flexboxGrid', property: 'gap', value: '0.625rem' },
+  'gap-3': { category: 'flexboxGrid', property: 'gap', value: '0.75rem' },
+  'gap-3.5': { category: 'flexboxGrid', property: 'gap', value: '0.875rem' },
+  'gap-4': { category: 'flexboxGrid', property: 'gap', value: '1rem' },
+  'gap-5': { category: 'flexboxGrid', property: 'gap', value: '1.25rem' },
+  'gap-6': { category: 'flexboxGrid', property: 'gap', value: '1.5rem' },
+  'gap-7': { category: 'flexboxGrid', property: 'gap', value: '1.75rem' },
+  'gap-8': { category: 'flexboxGrid', property: 'gap', value: '2rem' },
+  'gap-9': { category: 'flexboxGrid', property: 'gap', value: '2.25rem' },
+  'gap-10': { category: 'flexboxGrid', property: 'gap', value: '2.5rem' },
+  'gap-11': { category: 'flexboxGrid', property: 'gap', value: '2.75rem' },
+  'gap-12': { category: 'flexboxGrid', property: 'gap', value: '3rem' },
+  'gap-14': { category: 'flexboxGrid', property: 'gap', value: '3.5rem' },
+  'gap-16': { category: 'flexboxGrid', property: 'gap', value: '4rem' },
+  'gap-20': { category: 'flexboxGrid', property: 'gap', value: '5rem' },
+  'gap-24': { category: 'flexboxGrid', property: 'gap', value: '6rem' },
+  'gap-28': { category: 'flexboxGrid', property: 'gap', value: '7rem' },
+  'gap-32': { category: 'flexboxGrid', property: 'gap', value: '8rem' },
+  'gap-36': { category: 'flexboxGrid', property: 'gap', value: '9rem' },
+  'gap-40': { category: 'flexboxGrid', property: 'gap', value: '10rem' },
+  'gap-44': { category: 'flexboxGrid', property: 'gap', value: '11rem' },
+  'gap-48': { category: 'flexboxGrid', property: 'gap', value: '12rem' },
+  'gap-52': { category: 'flexboxGrid', property: 'gap', value: '13rem' },
+  'gap-56': { category: 'flexboxGrid', property: 'gap', value: '14rem' },
+  'gap-60': { category: 'flexboxGrid', property: 'gap', value: '15rem' },
+  'gap-64': { category: 'flexboxGrid', property: 'gap', value: '16rem' },
+  'gap-72': { category: 'flexboxGrid', property: 'gap', value: '18rem' },
+  'gap-80': { category: 'flexboxGrid', property: 'gap', value: '20rem' },
+  'gap-96': { category: 'flexboxGrid', property: 'gap', value: '24rem' },
+  'gap-px': { category: 'flexboxGrid', property: 'gap', value: '1px' },
+
+  // ============================================
+  // FLEX DIRECTION (flexboxGrid.flexDirection)
+  // ============================================
+  'flex-row': { category: 'flexboxGrid', property: 'flexDirection', value: 'row' },
+  'flex-row-reverse': { category: 'flexboxGrid', property: 'flexDirection', value: 'row-reverse' },
+  'flex-col': { category: 'flexboxGrid', property: 'flexDirection', value: 'column' },
+  'flex-col-reverse': { category: 'flexboxGrid', property: 'flexDirection', value: 'column-reverse' },
+
+  // ============================================
+  // FLEX WRAP (flexboxGrid.flexWrap)
+  // ============================================
+  'flex-wrap': { category: 'flexboxGrid', property: 'flexWrap', value: 'wrap' },
+  'flex-wrap-reverse': { category: 'flexboxGrid', property: 'flexWrap', value: 'wrap-reverse' },
+  'flex-nowrap': { category: 'flexboxGrid', property: 'flexWrap', value: 'nowrap' },
+
+  // ============================================
+  // FLEX GROW (flexboxGrid.flexGrow)
+  // ============================================
+  'grow': { category: 'flexboxGrid', property: 'flexGrow', value: 1 },
+  'grow-0': { category: 'flexboxGrid', property: 'flexGrow', value: 0 },
+
+  // ============================================
+  // FLEX SHRINK (flexboxGrid.flexShrink)
+  // ============================================
+  'shrink': { category: 'flexboxGrid', property: 'flexShrink', value: 1 },
+  'shrink-0': { category: 'flexboxGrid', property: 'flexShrink', value: 0 },
+
+  // ============================================
+  // FLEX BASIS (flexboxGrid.flexBasis)
+  // ============================================
+  'basis-0': { category: 'flexboxGrid', property: 'flexBasis', value: '0px' },
+  'basis-1': { category: 'flexboxGrid', property: 'flexBasis', value: '0.25rem' },
+  'basis-2': { category: 'flexboxGrid', property: 'flexBasis', value: '0.5rem' },
+  'basis-3': { category: 'flexboxGrid', property: 'flexBasis', value: '0.75rem' },
+  'basis-4': { category: 'flexboxGrid', property: 'flexBasis', value: '1rem' },
+  'basis-5': { category: 'flexboxGrid', property: 'flexBasis', value: '1.25rem' },
+  'basis-6': { category: 'flexboxGrid', property: 'flexBasis', value: '1.5rem' },
+  'basis-7': { category: 'flexboxGrid', property: 'flexBasis', value: '1.75rem' },
+  'basis-8': { category: 'flexboxGrid', property: 'flexBasis', value: '2rem' },
+  'basis-9': { category: 'flexboxGrid', property: 'flexBasis', value: '2.25rem' },
+  'basis-10': { category: 'flexboxGrid', property: 'flexBasis', value: '2.5rem' },
+  'basis-11': { category: 'flexboxGrid', property: 'flexBasis', value: '2.75rem' },
+  'basis-12': { category: 'flexboxGrid', property: 'flexBasis', value: '3rem' },
+  'basis-14': { category: 'flexboxGrid', property: 'flexBasis', value: '3.5rem' },
+  'basis-16': { category: 'flexboxGrid', property: 'flexBasis', value: '4rem' },
+  'basis-20': { category: 'flexboxGrid', property: 'flexBasis', value: '5rem' },
+  'basis-24': { category: 'flexboxGrid', property: 'flexBasis', value: '6rem' },
+  'basis-28': { category: 'flexboxGrid', property: 'flexBasis', value: '7rem' },
+  'basis-32': { category: 'flexboxGrid', property: 'flexBasis', value: '8rem' },
+  'basis-36': { category: 'flexboxGrid', property: 'flexBasis', value: '9rem' },
+  'basis-40': { category: 'flexboxGrid', property: 'flexBasis', value: '10rem' },
+  'basis-44': { category: 'flexboxGrid', property: 'flexBasis', value: '11rem' },
+  'basis-48': { category: 'flexboxGrid', property: 'flexBasis', value: '12rem' },
+  'basis-52': { category: 'flexboxGrid', property: 'flexBasis', value: '13rem' },
+  'basis-56': { category: 'flexboxGrid', property: 'flexBasis', value: '14rem' },
+  'basis-60': { category: 'flexboxGrid', property: 'flexBasis', value: '15rem' },
+  'basis-64': { category: 'flexboxGrid', property: 'flexBasis', value: '16rem' },
+  'basis-72': { category: 'flexboxGrid', property: 'flexBasis', value: '18rem' },
+  'basis-80': { category: 'flexboxGrid', property: 'flexBasis', value: '20rem' },
+  'basis-96': { category: 'flexboxGrid', property: 'flexBasis', value: '24rem' },
+  'basis-auto': { category: 'flexboxGrid', property: 'flexBasis', value: 'auto' },
+  'basis-px': { category: 'flexboxGrid', property: 'flexBasis', value: '1px' },
+  'basis-full': { category: 'flexboxGrid', property: 'flexBasis', value: '100%' },
+  'basis-1/2': { category: 'flexboxGrid', property: 'flexBasis', value: '50%' },
+  'basis-1/3': { category: 'flexboxGrid', property: 'flexBasis', value: '33.333333%' },
+  'basis-2/3': { category: 'flexboxGrid', property: 'flexBasis', value: '66.666667%' },
+  'basis-1/4': { category: 'flexboxGrid', property: 'flexBasis', value: '25%' },
+  'basis-2/4': { category: 'flexboxGrid', property: 'flexBasis', value: '50%' },
+  'basis-3/4': { category: 'flexboxGrid', property: 'flexBasis', value: '75%' },
+
+  // ============================================
+  // JUSTIFY CONTENT (flexboxGrid.justifyContent)
+  // ============================================
+  'justify-normal': { category: 'flexboxGrid', property: 'justifyContent', value: 'normal' },
+  'justify-start': { category: 'flexboxGrid', property: 'justifyContent', value: 'flex-start' },
+  'justify-end': { category: 'flexboxGrid', property: 'justifyContent', value: 'flex-end' },
+  'justify-center': { category: 'flexboxGrid', property: 'justifyContent', value: 'center' },
+  'justify-between': { category: 'flexboxGrid', property: 'justifyContent', value: 'space-between' },
+  'justify-around': { category: 'flexboxGrid', property: 'justifyContent', value: 'space-around' },
+  'justify-evenly': { category: 'flexboxGrid', property: 'justifyContent', value: 'space-evenly' },
+  'justify-stretch': { category: 'flexboxGrid', property: 'justifyContent', value: 'stretch' },
+
+  // ============================================
+  // JUSTIFY ITEMS (flexboxGrid.justifyItems)
+  // ============================================
+  'justify-items-start': { category: 'flexboxGrid', property: 'justifyItems', value: 'start' },
+  'justify-items-end': { category: 'flexboxGrid', property: 'justifyItems', value: 'end' },
+  'justify-items-center': { category: 'flexboxGrid', property: 'justifyItems', value: 'center' },
+  'justify-items-stretch': { category: 'flexboxGrid', property: 'justifyItems', value: 'stretch' },
+
+  // ============================================
+  // JUSTIFY SELF (flexboxGrid.justifySelf)
+  // ============================================
+  'justify-self-auto': { category: 'flexboxGrid', property: 'justifySelf', value: 'auto' },
+  'justify-self-start': { category: 'flexboxGrid', property: 'justifySelf', value: 'start' },
+  'justify-self-end': { category: 'flexboxGrid', property: 'justifySelf', value: 'end' },
+  'justify-self-center': { category: 'flexboxGrid', property: 'justifySelf', value: 'center' },
+  'justify-self-stretch': { category: 'flexboxGrid', property: 'justifySelf', value: 'stretch' },
+
+  // ============================================
+  // ALIGN ITEMS (flexboxGrid.alignItems)
+  // ============================================
+  'items-start': { category: 'flexboxGrid', property: 'alignItems', value: 'flex-start' },
+  'items-end': { category: 'flexboxGrid', property: 'alignItems', value: 'flex-end' },
+  'items-center': { category: 'flexboxGrid', property: 'alignItems', value: 'center' },
+  'items-baseline': { category: 'flexboxGrid', property: 'alignItems', value: 'baseline' },
+  'items-stretch': { category: 'flexboxGrid', property: 'alignItems', value: 'stretch' },
+
+  // ============================================
+  // ALIGN CONTENT (flexboxGrid.alignContent)
+  // ============================================
+  'content-normal': { category: 'flexboxGrid', property: 'alignContent', value: 'normal' },
+  'content-start': { category: 'flexboxGrid', property: 'alignContent', value: 'flex-start' },
+  'content-end': { category: 'flexboxGrid', property: 'alignContent', value: 'flex-end' },
+  'content-center': { category: 'flexboxGrid', property: 'alignContent', value: 'center' },
+  'content-between': { category: 'flexboxGrid', property: 'alignContent', value: 'space-between' },
+  'content-around': { category: 'flexboxGrid', property: 'alignContent', value: 'space-around' },
+  'content-evenly': { category: 'flexboxGrid', property: 'alignContent', value: 'space-evenly' },
+  'content-baseline': { category: 'flexboxGrid', property: 'alignContent', value: 'baseline' },
+  'content-stretch': { category: 'flexboxGrid', property: 'alignContent', value: 'stretch' },
+
+  // ============================================
+  // ALIGN SELF (flexboxGrid.alignSelf)
+  // ============================================
+  'self-auto': { category: 'flexboxGrid', property: 'alignSelf', value: 'auto' },
+  'self-start': { category: 'flexboxGrid', property: 'alignSelf', value: 'flex-start' },
+  'self-end': { category: 'flexboxGrid', property: 'alignSelf', value: 'flex-end' },
+  'self-center': { category: 'flexboxGrid', property: 'alignSelf', value: 'center' },
+  'self-stretch': { category: 'flexboxGrid', property: 'alignSelf', value: 'stretch' },
+  'self-baseline': { category: 'flexboxGrid', property: 'alignSelf', value: 'baseline' },
+
+  // ============================================
+  // PLACE ITEMS (flexboxGrid.placeItems)
+  // ============================================
+  'place-items-start': { category: 'flexboxGrid', property: 'placeItems', value: 'start' },
+  'place-items-end': { category: 'flexboxGrid', property: 'placeItems', value: 'end' },
+  'place-items-center': { category: 'flexboxGrid', property: 'placeItems', value: 'center' },
+  'place-items-baseline': { category: 'flexboxGrid', property: 'placeItems', value: 'baseline' },
+  'place-items-stretch': { category: 'flexboxGrid', property: 'placeItems', value: 'stretch' },
+
+  // ============================================
+  // GRID TEMPLATE COLUMNS (flexboxGrid.gridTemplateColumns)
+  // ============================================
+  'grid-cols-1': { category: 'flexboxGrid', property: 'gridTemplateColumns', value: 'repeat(1, minmax(0, 1fr))' },
+  'grid-cols-2': { category: 'flexboxGrid', property: 'gridTemplateColumns', value: 'repeat(2, minmax(0, 1fr))' },
+  'grid-cols-3': { category: 'flexboxGrid', property: 'gridTemplateColumns', value: 'repeat(3, minmax(0, 1fr))' },
+  'grid-cols-4': { category: 'flexboxGrid', property: 'gridTemplateColumns', value: 'repeat(4, minmax(0, 1fr))' },
+  'grid-cols-5': { category: 'flexboxGrid', property: 'gridTemplateColumns', value: 'repeat(5, minmax(0, 1fr))' },
+  'grid-cols-6': { category: 'flexboxGrid', property: 'gridTemplateColumns', value: 'repeat(6, minmax(0, 1fr))' },
+  'grid-cols-7': { category: 'flexboxGrid', property: 'gridTemplateColumns', value: 'repeat(7, minmax(0, 1fr))' },
+  'grid-cols-8': { category: 'flexboxGrid', property: 'gridTemplateColumns', value: 'repeat(8, minmax(0, 1fr))' },
+  'grid-cols-9': { category: 'flexboxGrid', property: 'gridTemplateColumns', value: 'repeat(9, minmax(0, 1fr))' },
+  'grid-cols-10': { category: 'flexboxGrid', property: 'gridTemplateColumns', value: 'repeat(10, minmax(0, 1fr))' },
+  'grid-cols-11': { category: 'flexboxGrid', property: 'gridTemplateColumns', value: 'repeat(11, minmax(0, 1fr))' },
+  'grid-cols-12': { category: 'flexboxGrid', property: 'gridTemplateColumns', value: 'repeat(12, minmax(0, 1fr))' },
+  'grid-cols-none': { category: 'flexboxGrid', property: 'gridTemplateColumns', value: 'none' },
+  'grid-cols-subgrid': { category: 'flexboxGrid', property: 'gridTemplateColumns', value: 'subgrid' },
+
+  // ============================================
+  // GRID TEMPLATE ROWS (flexboxGrid.gridTemplateRows)
+  // ============================================
+  'grid-rows-1': { category: 'flexboxGrid', property: 'gridTemplateRows', value: 'repeat(1, minmax(0, 1fr))' },
+  'grid-rows-2': { category: 'flexboxGrid', property: 'gridTemplateRows', value: 'repeat(2, minmax(0, 1fr))' },
+  'grid-rows-3': { category: 'flexboxGrid', property: 'gridTemplateRows', value: 'repeat(3, minmax(0, 1fr))' },
+  'grid-rows-4': { category: 'flexboxGrid', property: 'gridTemplateRows', value: 'repeat(4, minmax(0, 1fr))' },
+  'grid-rows-5': { category: 'flexboxGrid', property: 'gridTemplateRows', value: 'repeat(5, minmax(0, 1fr))' },
+  'grid-rows-6': { category: 'flexboxGrid', property: 'gridTemplateRows', value: 'repeat(6, minmax(0, 1fr))' },
+  'grid-rows-none': { category: 'flexboxGrid', property: 'gridTemplateRows', value: 'none' },
+  'grid-rows-subgrid': { category: 'flexboxGrid', property: 'gridTemplateRows', value: 'subgrid' },
+
+  // ============================================
+  // GRID COLUMN (flexboxGrid.gridColumn)
+  // ============================================
+  'col-auto': { category: 'flexboxGrid', property: 'gridColumn', value: 'auto' },
+  'col-span-1': { category: 'flexboxGrid', property: 'gridColumn', value: 'span 1 / span 1' },
+  'col-span-2': { category: 'flexboxGrid', property: 'gridColumn', value: 'span 2 / span 2' },
+  'col-span-3': { category: 'flexboxGrid', property: 'gridColumn', value: 'span 3 / span 3' },
+  'col-span-4': { category: 'flexboxGrid', property: 'gridColumn', value: 'span 4 / span 4' },
+  'col-span-5': { category: 'flexboxGrid', property: 'gridColumn', value: 'span 5 / span 5' },
+  'col-span-6': { category: 'flexboxGrid', property: 'gridColumn', value: 'span 6 / span 6' },
+  'col-span-7': { category: 'flexboxGrid', property: 'gridColumn', value: 'span 7 / span 7' },
+  'col-span-8': { category: 'flexboxGrid', property: 'gridColumn', value: 'span 8 / span 8' },
+  'col-span-9': { category: 'flexboxGrid', property: 'gridColumn', value: 'span 9 / span 9' },
+  'col-span-10': { category: 'flexboxGrid', property: 'gridColumn', value: 'span 10 / span 10' },
+  'col-span-11': { category: 'flexboxGrid', property: 'gridColumn', value: 'span 11 / span 11' },
+  'col-span-12': { category: 'flexboxGrid', property: 'gridColumn', value: 'span 12 / span 12' },
+  'col-span-full': { category: 'flexboxGrid', property: 'gridColumn', value: '1 / -1' },
+
+  // ============================================
+  // GRID COLUMN START (flexboxGrid.gridColumnStart)
+  // ============================================
+  'col-start-1': { category: 'flexboxGrid', property: 'gridColumnStart', value: '1' },
+  'col-start-2': { category: 'flexboxGrid', property: 'gridColumnStart', value: '2' },
+  'col-start-3': { category: 'flexboxGrid', property: 'gridColumnStart', value: '3' },
+  'col-start-4': { category: 'flexboxGrid', property: 'gridColumnStart', value: '4' },
+  'col-start-5': { category: 'flexboxGrid', property: 'gridColumnStart', value: '5' },
+  'col-start-6': { category: 'flexboxGrid', property: 'gridColumnStart', value: '6' },
+  'col-start-7': { category: 'flexboxGrid', property: 'gridColumnStart', value: '7' },
+  'col-start-8': { category: 'flexboxGrid', property: 'gridColumnStart', value: '8' },
+  'col-start-9': { category: 'flexboxGrid', property: 'gridColumnStart', value: '9' },
+  'col-start-10': { category: 'flexboxGrid', property: 'gridColumnStart', value: '10' },
+  'col-start-11': { category: 'flexboxGrid', property: 'gridColumnStart', value: '11' },
+  'col-start-12': { category: 'flexboxGrid', property: 'gridColumnStart', value: '12' },
+  'col-start-13': { category: 'flexboxGrid', property: 'gridColumnStart', value: '13' },
+  'col-start-auto': { category: 'flexboxGrid', property: 'gridColumnStart', value: 'auto' },
+
+  // ============================================
+  // GRID COLUMN END (flexboxGrid.gridColumnEnd)
+  // ============================================
+  'col-end-1': { category: 'flexboxGrid', property: 'gridColumnEnd', value: '1' },
+  'col-end-2': { category: 'flexboxGrid', property: 'gridColumnEnd', value: '2' },
+  'col-end-3': { category: 'flexboxGrid', property: 'gridColumnEnd', value: '3' },
+  'col-end-4': { category: 'flexboxGrid', property: 'gridColumnEnd', value: '4' },
+  'col-end-5': { category: 'flexboxGrid', property: 'gridColumnEnd', value: '5' },
+  'col-end-6': { category: 'flexboxGrid', property: 'gridColumnEnd', value: '6' },
+  'col-end-7': { category: 'flexboxGrid', property: 'gridColumnEnd', value: '7' },
+  'col-end-8': { category: 'flexboxGrid', property: 'gridColumnEnd', value: '8' },
+  'col-end-9': { category: 'flexboxGrid', property: 'gridColumnEnd', value: '9' },
+  'col-end-10': { category: 'flexboxGrid', property: 'gridColumnEnd', value: '10' },
+  'col-end-11': { category: 'flexboxGrid', property: 'gridColumnEnd', value: '11' },
+  'col-end-12': { category: 'flexboxGrid', property: 'gridColumnEnd', value: '12' },
+  'col-end-13': { category: 'flexboxGrid', property: 'gridColumnEnd', value: '13' },
+  'col-end-auto': { category: 'flexboxGrid', property: 'gridColumnEnd', value: 'auto' },
+
+  // ============================================
+  // GRID ROW (flexboxGrid.gridRow)
+  // ============================================
+  'row-auto': { category: 'flexboxGrid', property: 'gridRow', value: 'auto' },
+  'row-span-1': { category: 'flexboxGrid', property: 'gridRow', value: 'span 1 / span 1' },
+  'row-span-2': { category: 'flexboxGrid', property: 'gridRow', value: 'span 2 / span 2' },
+  'row-span-3': { category: 'flexboxGrid', property: 'gridRow', value: 'span 3 / span 3' },
+  'row-span-4': { category: 'flexboxGrid', property: 'gridRow', value: 'span 4 / span 4' },
+  'row-span-5': { category: 'flexboxGrid', property: 'gridRow', value: 'span 5 / span 5' },
+  'row-span-6': { category: 'flexboxGrid', property: 'gridRow', value: 'span 6 / span 6' },
+  'row-span-full': { category: 'flexboxGrid', property: 'gridRow', value: '1 / -1' },
+
+  // ============================================
+  // GRID ROW START (flexboxGrid.gridRowStart)
+  // ============================================
+  'row-start-1': { category: 'flexboxGrid', property: 'gridRowStart', value: '1' },
+  'row-start-2': { category: 'flexboxGrid', property: 'gridRowStart', value: '2' },
+  'row-start-3': { category: 'flexboxGrid', property: 'gridRowStart', value: '3' },
+  'row-start-4': { category: 'flexboxGrid', property: 'gridRowStart', value: '4' },
+  'row-start-5': { category: 'flexboxGrid', property: 'gridRowStart', value: '5' },
+  'row-start-6': { category: 'flexboxGrid', property: 'gridRowStart', value: '6' },
+  'row-start-7': { category: 'flexboxGrid', property: 'gridRowStart', value: '7' },
+  'row-start-auto': { category: 'flexboxGrid', property: 'gridRowStart', value: 'auto' },
+
+  // ============================================
+  // GRID ROW END (flexboxGrid.gridRowEnd)
+  // ============================================
+  'row-end-1': { category: 'flexboxGrid', property: 'gridRowEnd', value: '1' },
+  'row-end-2': { category: 'flexboxGrid', property: 'gridRowEnd', value: '2' },
+  'row-end-3': { category: 'flexboxGrid', property: 'gridRowEnd', value: '3' },
+  'row-end-4': { category: 'flexboxGrid', property: 'gridRowEnd', value: '4' },
+  'row-end-5': { category: 'flexboxGrid', property: 'gridRowEnd', value: '5' },
+  'row-end-6': { category: 'flexboxGrid', property: 'gridRowEnd', value: '6' },
+  'row-end-7': { category: 'flexboxGrid', property: 'gridRowEnd', value: '7' },
+  'row-end-auto': { category: 'flexboxGrid', property: 'gridRowEnd', value: 'auto' },
+
+  // ============================================
+  // GRID AUTO FLOW (flexboxGrid.gridAutoFlow)
+  // ============================================
+  'grid-flow-row': { category: 'flexboxGrid', property: 'gridAutoFlow', value: 'row' },
+  'grid-flow-col': { category: 'flexboxGrid', property: 'gridAutoFlow', value: 'column' },
+  'grid-flow-dense': { category: 'flexboxGrid', property: 'gridAutoFlow', value: 'dense' },
+  'grid-flow-row-dense': { category: 'flexboxGrid', property: 'gridAutoFlow', value: 'row dense' },
+  'grid-flow-col-dense': { category: 'flexboxGrid', property: 'gridAutoFlow', value: 'column dense' },
+
+  // ============================================
+  // GRID AUTO COLUMNS (flexboxGrid.gridAutoColumns)
+  // ============================================
+  'auto-cols-auto': { category: 'flexboxGrid', property: 'gridAutoColumns', value: 'auto' },
+  'auto-cols-min': { category: 'flexboxGrid', property: 'gridAutoColumns', value: 'min-content' },
+  'auto-cols-max': { category: 'flexboxGrid', property: 'gridAutoColumns', value: 'max-content' },
+  'auto-cols-fr': { category: 'flexboxGrid', property: 'gridAutoColumns', value: 'minmax(0, 1fr)' },
+
+  // ============================================
+  // GRID AUTO ROWS (flexboxGrid.gridAutoRows)
+  // ============================================
+  'auto-rows-auto': { category: 'flexboxGrid', property: 'gridAutoRows', value: 'auto' },
+  'auto-rows-min': { category: 'flexboxGrid', property: 'gridAutoRows', value: 'min-content' },
+  'auto-rows-max': { category: 'flexboxGrid', property: 'gridAutoRows', value: 'max-content' },
+  'auto-rows-fr': { category: 'flexboxGrid', property: 'gridAutoRows', value: 'minmax(0, 1fr)' },
+};
+
+/**
+ * Build a reverse map from CSS values to Tailwind classes.
+ * Key format: "category.property:value"
+ */
+export function buildCssToTailwindMap(): Map<string, string> {
+  const map = new Map<string, string>();
+
+  for (const [tailwindClass, mapping] of Object.entries(TAILWIND_TO_CSS_MAP)) {
+    const key = `${mapping.category}.${mapping.property}:${mapping.value}`;
+    // Don't overwrite if we already have a mapping (prefer shorter class names)
+    if (!map.has(key)) {
+      map.set(key, tailwindClass);
+    }
+  }
+
+  return map;
+}

--- a/libs/shared/src/lib/code-editor/code-editor.component.ts
+++ b/libs/shared/src/lib/code-editor/code-editor.component.ts
@@ -21,24 +21,39 @@ import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
     <div #editorContainer class="code-editor-container"></div>
   `,
   styles: `
+    :host {
+      display: block;
+      width: 100%;
+      min-width: 0;
+    }
+
     .code-editor-container {
       border: 1px solid var(--border-color);
       border-radius: 6px;
       overflow: hidden;
+      width: 100%;
+      min-width: 0;
 
       :global(.cm-editor) {
         background: var(--surface-ground);
         font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
         font-size: 13px;
+        max-width: 100%;
+      }
+
+      :global(.cm-scroller) {
+        overflow-x: hidden !important;
       }
 
       :global(.cm-content) {
         padding: 8px 4px;
         min-height: 32px;
+        max-width: 100%;
       }
 
       :global(.cm-line) {
         padding: 0 8px;
+        word-break: break-word;
       }
 
       :global(.cm-focused) {
@@ -118,10 +133,12 @@ export class CodeEditorComponent implements ControlValueAccessor {
       baseExtensions.push(placeholderExtension(this.placeholder()));
     }
 
-    // Add line wrapping for single-line mode
+    // Always enable line wrapping to prevent horizontal overflow
+    baseExtensions.push(EditorView.lineWrapping);
+
+    // Prevent Enter key in single-line mode
     if (!this.multiline()) {
       baseExtensions.push(
-        EditorView.lineWrapping,
         keymap.of([
           {
             key: 'Enter',


### PR DESCRIPTION
Create bidirectional sync between CSS properties and Tailwind classes:
- TailwindCssConverter service for CSS↔Tailwind conversion
- TailwindPanelComponent with compact/full modes
- Refactor CssTailwindSerializer to use shared converter
- Add comprehensive unit tests (101 tests total)

When users edit CSS properties, Tailwind classes update automatically. When users type Tailwind classes, CSS properties sync accordingly. Unsupported classes (colors, variants, etc.) are preserved separately.